### PR TITLE
Misc fixes

### DIFF
--- a/TieForm.Designer.cs
+++ b/TieForm.Designer.cs
@@ -1034,12 +1034,12 @@ namespace Idmr.Yogeme
 			// 
 			this.numSC.Location = new System.Drawing.Point(96, 112);
 			this.numSC.Maximum = new decimal(new int[] {
-            6,
+            255,
             0,
             0,
             0});
 			this.numSC.Name = "numSC";
-			this.numSC.Size = new System.Drawing.Size(32, 20);
+			this.numSC.Size = new System.Drawing.Size(42, 20);
 			this.numSC.TabIndex = 8;
 			this.numSC.Value = new decimal(new int[] {
             2,

--- a/XvtForm.Designer.cs
+++ b/XvtForm.Designer.cs
@@ -860,12 +860,12 @@ namespace Idmr.Yogeme
 			// 
 			this.numSC.Location = new System.Drawing.Point(96, 88);
 			this.numSC.Maximum = new decimal(new int[] {
-            6,
+            255,
             0,
             0,
             0});
 			this.numSC.Name = "numSC";
-			this.numSC.Size = new System.Drawing.Size(32, 20);
+			this.numSC.Size = new System.Drawing.Size(42, 20);
 			this.numSC.TabIndex = 8;
 			this.numSC.ValueChanged += new System.EventHandler(this.numSC_ValueChanged);
 			// 

--- a/XwaForm.Designer.cs
+++ b/XwaForm.Designer.cs
@@ -1586,12 +1586,12 @@ namespace Idmr.Yogeme
 			// 
 			this.numSC.Location = new System.Drawing.Point(96, 88);
 			this.numSC.Maximum = new decimal(new int[] {
-            6,
+            255,
             0,
             0,
             0});
 			this.numSC.Name = "numSC";
-			this.numSC.Size = new System.Drawing.Size(32, 20);
+			this.numSC.Size = new System.Drawing.Size(42, 20);
 			this.numSC.TabIndex = 8;
 			this.numSC.ValueChanged += new System.EventHandler(this.numSC_ValueChanged);
 			// 

--- a/XwingForm.Designer.cs
+++ b/XwingForm.Designer.cs
@@ -872,12 +872,12 @@ namespace Idmr.Yogeme
 			// 
 			this.numSC.Location = new System.Drawing.Point(96, 112);
 			this.numSC.Maximum = new decimal(new int[] {
-            9,
+            255,
             0,
             0,
             0});
 			this.numSC.Name = "numSC";
-			this.numSC.Size = new System.Drawing.Size(32, 20);
+			this.numSC.Size = new System.Drawing.Size(42, 20);
 			this.numSC.TabIndex = 8;
 			this.numSC.ValueChanged += new System.EventHandler(this.numSC_ValueChanged);
 			// 

--- a/classes/MapWireframe.cs
+++ b/classes/MapWireframe.cs
@@ -1079,7 +1079,7 @@ namespace Idmr.Yogeme
 				}
 				else if (_curOrientation == MapForm.Orientation.YZ)
 				{
-					yaw = -Math.Atan2(_dstX - _curX, _curY - _dstY);
+					yaw = Math.Atan2(_dstX - _curX, -_curY - -_dstY);
 					pitch = -Math.Atan2(diffZ, Math.Sqrt(diffX * diffX + diffY * diffY));
 				}
 				if (yaw > Math.PI)

--- a/craft_data_xw.txt
+++ b/craft_data_xw.txt
@@ -115,9 +115,4 @@ Nav Buoy 1,NAV 1,0,probea
 Nav Buoy 2,NAV 2,0,probea
 Asteroid Field 1,Asteroid,0,astroid1
 Asteroid Field 2,Asteroid,0,astroid2
-Asteroid3,Asteroid3,0,ASTROID3
-Asteroid4,Asteroid4,0,ASTROID4
-Asteroid5,Asteroid5,0,ASTROID5
-Asteroid6,Asteroid6,0,ASTROID6
-Asteroid7,Asteroid5,0,ASTROID1
-Asteroid8,Asteroid6,0,ASTROID2
+Planet,Planet,,


### PR DESCRIPTION
Two fixes to wireframe.
Updated special cargo index to allow a max range that corresponds with wave count.  Control size adjusted to compensate.
XvT briefing tags will scan image size instead of loading from deprecated .dat file.  No longer a dependency (see comment at bottom of BriefingForm.cs).