### PR TITLE
FG Library feature, XvT unknowns, XWA hook bug fixes

### DIFF
--- a/FlightGroupLibraryForm.Designer.cs
+++ b/FlightGroupLibraryForm.Designer.cs
@@ -1,0 +1,394 @@
+﻿namespace Idmr.Yogeme
+{
+	partial class FlightGroupLibraryForm
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FlightGroupLibraryForm));
+			this.cboLibraryGroup = new System.Windows.Forms.ComboBox();
+			this.cmdNewGroup = new System.Windows.Forms.Button();
+			this.cmdDeleteGroup = new System.Windows.Forms.Button();
+			this.label2 = new System.Windows.Forms.Label();
+			this.lstMissionCraft = new System.Windows.Forms.ListBox();
+			this.lstLibraryCraft = new System.Windows.Forms.ListBox();
+			this.label3 = new System.Windows.Forms.Label();
+			this.cmdAddToLibrary = new System.Windows.Forms.Button();
+			this.cmdAddToMission = new System.Windows.Forms.Button();
+			this.lblMissionCraft = new System.Windows.Forms.Label();
+			this.lblLibraryCraft = new System.Windows.Forms.Label();
+			this.txtName = new System.Windows.Forms.TextBox();
+			this.cmdRenameGroup = new System.Windows.Forms.Button();
+			this.cmdDeleteCraft = new System.Windows.Forms.Button();
+			this.lstLibraryGroup = new System.Windows.Forms.ListBox();
+			this.grpGroup = new System.Windows.Forms.GroupBox();
+			this.cmdMoveCraftUp = new System.Windows.Forms.Button();
+			this.cmdMoveCraftDown = new System.Windows.Forms.Button();
+			this.label1 = new System.Windows.Forms.Label();
+			this.cmdMoveCraftToGroup = new System.Windows.Forms.Button();
+			this.grpCraftManager = new System.Windows.Forms.GroupBox();
+			this.label5 = new System.Windows.Forms.Label();
+			this.cmdScrubProblems = new System.Windows.Forms.Button();
+			this.cmdViewProblems = new System.Windows.Forms.Button();
+			this.label4 = new System.Windows.Forms.Label();
+			this.chkAutoscrubAddMission = new System.Windows.Forms.CheckBox();
+			this.grpGroup.SuspendLayout();
+			this.grpCraftManager.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// cboLibraryGroup
+			// 
+			this.cboLibraryGroup.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboLibraryGroup.FormattingEnabled = true;
+			this.cboLibraryGroup.Location = new System.Drawing.Point(10, 84);
+			this.cboLibraryGroup.Name = "cboLibraryGroup";
+			this.cboLibraryGroup.Size = new System.Drawing.Size(127, 21);
+			this.cboLibraryGroup.TabIndex = 16;
+			// 
+			// cmdNewGroup
+			// 
+			this.cmdNewGroup.Location = new System.Drawing.Point(25, 117);
+			this.cmdNewGroup.Name = "cmdNewGroup";
+			this.cmdNewGroup.Size = new System.Drawing.Size(46, 23);
+			this.cmdNewGroup.TabIndex = 3;
+			this.cmdNewGroup.Text = "New";
+			this.cmdNewGroup.UseVisualStyleBackColor = true;
+			this.cmdNewGroup.Click += new System.EventHandler(this.cmdNewGroup_Click);
+			// 
+			// cmdDeleteGroup
+			// 
+			this.cmdDeleteGroup.Location = new System.Drawing.Point(125, 117);
+			this.cmdDeleteGroup.Name = "cmdDeleteGroup";
+			this.cmdDeleteGroup.Size = new System.Drawing.Size(46, 23);
+			this.cmdDeleteGroup.TabIndex = 4;
+			this.cmdDeleteGroup.Text = "Delete";
+			this.cmdDeleteGroup.UseVisualStyleBackColor = true;
+			this.cmdDeleteGroup.Click += new System.EventHandler(this.cmdDeleteGroup_Click);
+			// 
+			// label2
+			// 
+			this.label2.AutoSize = true;
+			this.label2.Location = new System.Drawing.Point(12, 20);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(115, 13);
+			this.label2.TabIndex = 3;
+			this.label2.Text = "FlightGroups in Mission";
+			// 
+			// lstMissionCraft
+			// 
+			this.lstMissionCraft.BackColor = System.Drawing.Color.Black;
+			this.lstMissionCraft.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+			this.lstMissionCraft.FormattingEnabled = true;
+			this.lstMissionCraft.Location = new System.Drawing.Point(15, 59);
+			this.lstMissionCraft.Name = "lstMissionCraft";
+			this.lstMissionCraft.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+			this.lstMissionCraft.Size = new System.Drawing.Size(213, 498);
+			this.lstMissionCraft.TabIndex = 7;
+			this.lstMissionCraft.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lstMissionCraft_DrawItem);
+			// 
+			// lstLibraryCraft
+			// 
+			this.lstLibraryCraft.BackColor = System.Drawing.Color.Black;
+			this.lstLibraryCraft.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+			this.lstLibraryCraft.FormattingEnabled = true;
+			this.lstLibraryCraft.Location = new System.Drawing.Point(436, 59);
+			this.lstLibraryCraft.Name = "lstLibraryCraft";
+			this.lstLibraryCraft.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+			this.lstLibraryCraft.Size = new System.Drawing.Size(223, 498);
+			this.lstLibraryCraft.TabIndex = 8;
+			this.lstLibraryCraft.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lstGroupCraft_DrawItem);
+			// 
+			// label3
+			// 
+			this.label3.AutoSize = true;
+			this.label3.Location = new System.Drawing.Point(433, 20);
+			this.label3.Name = "label3";
+			this.label3.Size = new System.Drawing.Size(143, 13);
+			this.label3.TabIndex = 6;
+			this.label3.Text = "FlightGroups in Library Group";
+			// 
+			// cmdAddToLibrary
+			// 
+			this.cmdAddToLibrary.Location = new System.Drawing.Point(234, 229);
+			this.cmdAddToLibrary.Name = "cmdAddToLibrary";
+			this.cmdAddToLibrary.Size = new System.Drawing.Size(117, 23);
+			this.cmdAddToLibrary.TabIndex = 9;
+			this.cmdAddToLibrary.Text = "Add To Library >>";
+			this.cmdAddToLibrary.UseVisualStyleBackColor = true;
+			this.cmdAddToLibrary.Click += new System.EventHandler(this.cmdAddToLibrary_Click);
+			// 
+			// cmdAddToMission
+			// 
+			this.cmdAddToMission.Location = new System.Drawing.Point(311, 272);
+			this.cmdAddToMission.Name = "cmdAddToMission";
+			this.cmdAddToMission.Size = new System.Drawing.Size(117, 23);
+			this.cmdAddToMission.TabIndex = 10;
+			this.cmdAddToMission.Text = "<< Add To Mission";
+			this.cmdAddToMission.UseVisualStyleBackColor = true;
+			this.cmdAddToMission.Click += new System.EventHandler(this.cmdAddToMission_Click);
+			// 
+			// lblMissionCraft
+			// 
+			this.lblMissionCraft.AutoSize = true;
+			this.lblMissionCraft.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lblMissionCraft.Location = new System.Drawing.Point(12, 42);
+			this.lblMissionCraft.Name = "lblMissionCraft";
+			this.lblMissionCraft.Size = new System.Drawing.Size(143, 13);
+			this.lblMissionCraft.TabIndex = 8;
+			this.lblMissionCraft.Text = "Tm - GG  - waves x craft (GU)";
+			// 
+			// lblLibraryCraft
+			// 
+			this.lblLibraryCraft.AutoSize = true;
+			this.lblLibraryCraft.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lblLibraryCraft.Location = new System.Drawing.Point(433, 42);
+			this.lblLibraryCraft.Name = "lblLibraryCraft";
+			this.lblLibraryCraft.Size = new System.Drawing.Size(143, 13);
+			this.lblLibraryCraft.TabIndex = 9;
+			this.lblLibraryCraft.Text = "Tm - GG  - waves x craft (GU)";
+			// 
+			// txtName
+			// 
+			this.txtName.Location = new System.Drawing.Point(10, 150);
+			this.txtName.Name = "txtName";
+			this.txtName.Size = new System.Drawing.Size(113, 20);
+			this.txtName.TabIndex = 5;
+			// 
+			// cmdRenameGroup
+			// 
+			this.cmdRenameGroup.Location = new System.Drawing.Point(129, 148);
+			this.cmdRenameGroup.Name = "cmdRenameGroup";
+			this.cmdRenameGroup.Size = new System.Drawing.Size(56, 23);
+			this.cmdRenameGroup.TabIndex = 6;
+			this.cmdRenameGroup.Text = "Rename";
+			this.cmdRenameGroup.UseVisualStyleBackColor = true;
+			this.cmdRenameGroup.Click += new System.EventHandler(this.cmdRenameGroup_Click);
+			// 
+			// cmdDeleteCraft
+			// 
+			this.cmdDeleteCraft.Location = new System.Drawing.Point(134, 48);
+			this.cmdDeleteCraft.Name = "cmdDeleteCraft";
+			this.cmdDeleteCraft.Size = new System.Drawing.Size(51, 23);
+			this.cmdDeleteCraft.TabIndex = 15;
+			this.cmdDeleteCraft.Text = "Delete";
+			this.cmdDeleteCraft.UseVisualStyleBackColor = true;
+			this.cmdDeleteCraft.Click += new System.EventHandler(this.cmdDeleteCraft_Click);
+			// 
+			// lstLibraryGroup
+			// 
+			this.lstLibraryGroup.Location = new System.Drawing.Point(10, 29);
+			this.lstLibraryGroup.Margin = new System.Windows.Forms.Padding(7, 3, 7, 3);
+			this.lstLibraryGroup.Name = "lstLibraryGroup";
+			this.lstLibraryGroup.Size = new System.Drawing.Size(176, 82);
+			this.lstLibraryGroup.TabIndex = 2;
+			this.lstLibraryGroup.SelectedIndexChanged += new System.EventHandler(this.lstLibraryGroup_SelectedIndexChanged);
+			// 
+			// grpGroup
+			// 
+			this.grpGroup.Controls.Add(this.lstLibraryGroup);
+			this.grpGroup.Controls.Add(this.txtName);
+			this.grpGroup.Controls.Add(this.cmdRenameGroup);
+			this.grpGroup.Controls.Add(this.cmdDeleteGroup);
+			this.grpGroup.Controls.Add(this.cmdNewGroup);
+			this.grpGroup.Location = new System.Drawing.Point(234, 12);
+			this.grpGroup.Name = "grpGroup";
+			this.grpGroup.Size = new System.Drawing.Size(196, 182);
+			this.grpGroup.TabIndex = 1;
+			this.grpGroup.TabStop = false;
+			this.grpGroup.Text = "Manage Library Groups";
+			// 
+			// cmdMoveCraftUp
+			// 
+			this.cmdMoveCraftUp.Location = new System.Drawing.Point(77, 19);
+			this.cmdMoveCraftUp.Name = "cmdMoveCraftUp";
+			this.cmdMoveCraftUp.Size = new System.Drawing.Size(51, 23);
+			this.cmdMoveCraftUp.TabIndex = 13;
+			this.cmdMoveCraftUp.Text = "Up";
+			this.cmdMoveCraftUp.UseVisualStyleBackColor = true;
+			this.cmdMoveCraftUp.Click += new System.EventHandler(this.cmdMoveCraftUp_Click);
+			// 
+			// cmdMoveCraftDown
+			// 
+			this.cmdMoveCraftDown.Location = new System.Drawing.Point(134, 19);
+			this.cmdMoveCraftDown.Name = "cmdMoveCraftDown";
+			this.cmdMoveCraftDown.Size = new System.Drawing.Size(51, 23);
+			this.cmdMoveCraftDown.TabIndex = 14;
+			this.cmdMoveCraftDown.Text = "Down";
+			this.cmdMoveCraftDown.UseVisualStyleBackColor = true;
+			this.cmdMoveCraftDown.Click += new System.EventHandler(this.cmdMoveCraftDown_Click);
+			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(7, 65);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(81, 13);
+			this.label1.TabIndex = 15;
+			this.label1.Text = "Move to Group:";
+			// 
+			// cmdMoveCraftToGroup
+			// 
+			this.cmdMoveCraftToGroup.Location = new System.Drawing.Point(143, 82);
+			this.cmdMoveCraftToGroup.Name = "cmdMoveCraftToGroup";
+			this.cmdMoveCraftToGroup.Size = new System.Drawing.Size(42, 23);
+			this.cmdMoveCraftToGroup.TabIndex = 17;
+			this.cmdMoveCraftToGroup.Text = "Move";
+			this.cmdMoveCraftToGroup.UseVisualStyleBackColor = true;
+			this.cmdMoveCraftToGroup.Click += new System.EventHandler(this.cmdMoveCraftToGroup_Click);
+			// 
+			// grpCraftManager
+			// 
+			this.grpCraftManager.Controls.Add(this.label5);
+			this.grpCraftManager.Controls.Add(this.cmdScrubProblems);
+			this.grpCraftManager.Controls.Add(this.cmdViewProblems);
+			this.grpCraftManager.Controls.Add(this.label4);
+			this.grpCraftManager.Controls.Add(this.label1);
+			this.grpCraftManager.Controls.Add(this.cmdMoveCraftDown);
+			this.grpCraftManager.Controls.Add(this.cmdMoveCraftUp);
+			this.grpCraftManager.Controls.Add(this.cmdMoveCraftToGroup);
+			this.grpCraftManager.Controls.Add(this.cmdDeleteCraft);
+			this.grpCraftManager.Controls.Add(this.cboLibraryGroup);
+			this.grpCraftManager.Location = new System.Drawing.Point(234, 333);
+			this.grpCraftManager.Name = "grpCraftManager";
+			this.grpCraftManager.Size = new System.Drawing.Size(196, 153);
+			this.grpCraftManager.TabIndex = 12;
+			this.grpCraftManager.TabStop = false;
+			this.grpCraftManager.Text = "Manage selected craft in Library";
+			// 
+			// label5
+			// 
+			this.label5.AutoSize = true;
+			this.label5.Location = new System.Drawing.Point(12, 125);
+			this.label5.Name = "label5";
+			this.label5.Size = new System.Drawing.Size(53, 13);
+			this.label5.TabIndex = 19;
+			this.label5.Text = "Problems:";
+			// 
+			// cmdScrubProblems
+			// 
+			this.cmdScrubProblems.Location = new System.Drawing.Point(129, 120);
+			this.cmdScrubProblems.Name = "cmdScrubProblems";
+			this.cmdScrubProblems.Size = new System.Drawing.Size(52, 23);
+			this.cmdScrubProblems.TabIndex = 19;
+			this.cmdScrubProblems.Text = "Scrub";
+			this.cmdScrubProblems.UseVisualStyleBackColor = true;
+			this.cmdScrubProblems.Click += new System.EventHandler(this.cmdScrubProblems_Click);
+			// 
+			// cmdViewProblems
+			// 
+			this.cmdViewProblems.Location = new System.Drawing.Point(71, 120);
+			this.cmdViewProblems.Name = "cmdViewProblems";
+			this.cmdViewProblems.Size = new System.Drawing.Size(52, 23);
+			this.cmdViewProblems.TabIndex = 18;
+			this.cmdViewProblems.Text = "View";
+			this.cmdViewProblems.UseVisualStyleBackColor = true;
+			this.cmdViewProblems.Click += new System.EventHandler(this.cmdViewProblems_Click);
+			// 
+			// label4
+			// 
+			this.label4.AutoSize = true;
+			this.label4.Location = new System.Drawing.Point(34, 24);
+			this.label4.Name = "label4";
+			this.label4.Size = new System.Drawing.Size(37, 13);
+			this.label4.TabIndex = 16;
+			this.label4.Text = "Move:";
+			// 
+			// chkAutoscrubAddMission
+			// 
+			this.chkAutoscrubAddMission.AutoSize = true;
+			this.chkAutoscrubAddMission.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+			this.chkAutoscrubAddMission.Checked = true;
+			this.chkAutoscrubAddMission.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chkAutoscrubAddMission.Location = new System.Drawing.Point(290, 300);
+			this.chkAutoscrubAddMission.Name = "chkAutoscrubAddMission";
+			this.chkAutoscrubAddMission.Size = new System.Drawing.Size(138, 17);
+			this.chkAutoscrubAddMission.TabIndex = 11;
+			this.chkAutoscrubAddMission.Text = "Autoscrub when adding";
+			this.chkAutoscrubAddMission.UseVisualStyleBackColor = true;
+			// 
+			// FlightGroupLibraryForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(675, 557);
+			this.Controls.Add(this.chkAutoscrubAddMission);
+			this.Controls.Add(this.grpCraftManager);
+			this.Controls.Add(this.grpGroup);
+			this.Controls.Add(this.lblLibraryCraft);
+			this.Controls.Add(this.lblMissionCraft);
+			this.Controls.Add(this.cmdAddToMission);
+			this.Controls.Add(this.cmdAddToLibrary);
+			this.Controls.Add(this.label3);
+			this.Controls.Add(this.lstLibraryCraft);
+			this.Controls.Add(this.lstMissionCraft);
+			this.Controls.Add(this.label2);
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MaximumSize = new System.Drawing.Size(691, 2048);
+			this.MinimumSize = new System.Drawing.Size(691, 532);
+			this.Name = "FlightGroupLibraryForm";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+			this.Text = "FlightGroup Library";
+			this.Activated += new System.EventHandler(this.FlightGroupLibraryForm_Activated);
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FlightGroupLibraryForm_FormClosing);
+			this.SizeChanged += new System.EventHandler(this.FlightGroupLibraryForm_SizeChanged);
+			this.grpGroup.ResumeLayout(false);
+			this.grpGroup.PerformLayout();
+			this.grpCraftManager.ResumeLayout(false);
+			this.grpCraftManager.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+		private System.Windows.Forms.ComboBox cboLibraryGroup;
+		private System.Windows.Forms.Button cmdNewGroup;
+		private System.Windows.Forms.Button cmdDeleteGroup;
+		private System.Windows.Forms.Label label2;
+		private System.Windows.Forms.ListBox lstMissionCraft;
+		private System.Windows.Forms.ListBox lstLibraryCraft;
+		private System.Windows.Forms.Label label3;
+		private System.Windows.Forms.Button cmdAddToLibrary;
+		private System.Windows.Forms.Button cmdAddToMission;
+		private System.Windows.Forms.Label lblMissionCraft;
+		private System.Windows.Forms.Label lblLibraryCraft;
+		private System.Windows.Forms.TextBox txtName;
+		private System.Windows.Forms.Button cmdRenameGroup;
+		private System.Windows.Forms.Button cmdDeleteCraft;
+		private System.Windows.Forms.ListBox lstLibraryGroup;
+		private System.Windows.Forms.GroupBox grpGroup;
+		private System.Windows.Forms.Button cmdMoveCraftUp;
+		private System.Windows.Forms.Button cmdMoveCraftDown;
+		private System.Windows.Forms.Label label1;
+		private System.Windows.Forms.Button cmdMoveCraftToGroup;
+		private System.Windows.Forms.GroupBox grpCraftManager;
+		private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.Button cmdScrubProblems;
+		private System.Windows.Forms.Button cmdViewProblems;
+		private System.Windows.Forms.Label label5;
+		private System.Windows.Forms.CheckBox chkAutoscrubAddMission;
+	}
+}

--- a/FlightGroupLibraryForm.cs
+++ b/FlightGroupLibraryForm.cs
@@ -1,0 +1,877 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System.IO;
+
+namespace Idmr.Yogeme
+{
+	public partial class FlightGroupLibraryForm : Form
+	{
+		const int LibraryHeaderId = 0x4C474659;      // "YFGL" header signature.
+		const int LibraryVersion = 1;
+		
+		Settings.Platform _platform = Settings.Platform.None;
+		object _flightGroupCollection = null;
+		EventHandler _onAddEvent;
+
+		List<List<object>> _groupList = null;        // A list of library groups, each group containing a list of craft objects. Each craft object may be casted to a platform-specific FlightGroup.
+		List<string> _groupNames = null;             // User-defined names for each library.
+		List<List<string>> _craftProblems = null;    // A list of logic issues of all items in the current library group. Each FlightGroup contains a list of strings describing any problems. Logic issues are direct FG references that may cause unintended behavior if added to a mission without scrubbing them.
+
+		bool _loading = false;
+		bool _isDirty = false;
+
+		/// <summary>Initializes and prepares the FG Library for the specified platform.</summary>
+		/// <remarks>The library is saved automatically when the form is closed.</remarks>
+		/// <param name="platform">The platform determines which library to load, and how to access its data.</param>
+		/// <param name="flightGroupCollection">The collection of craft currently in the mission. Must be a valid FlightGroupCollection object.</param>
+		/// <param name="onAddCallback">Event to call when the user requests to add FlightGroups into the mission.</param>
+		/// <exception cref="ArgumentNullException">The FlightGroupCollection or callback event is null.</exception>
+		/// <exception cref="ArgumentException">The supplied FlightGroupCollection does not match expected type for the platform.</exception>
+		public FlightGroupLibraryForm(Settings.Platform platform, object flightGroupCollection, EventHandler onAddEvent)
+		{
+			InitializeComponent();
+
+			if (flightGroupCollection == null || onAddEvent == null)
+				throw new ArgumentNullException("Invalid arguments to FG Library");
+
+			string collectionType = flightGroupCollection.GetType().ToString();
+			string requiredType = "";
+			switch (platform)
+			{
+				case Settings.Platform.XWING: requiredType = typeof(Platform.Xwing.FlightGroupCollection).ToString(); break;
+				case Settings.Platform.TIE: requiredType = typeof(Platform.Tie.FlightGroupCollection).ToString(); break;
+				case Settings.Platform.XvT: case Settings.Platform.BoP: requiredType = typeof(Platform.Xvt.FlightGroupCollection).ToString(); break;
+				case Settings.Platform.XWA: requiredType = typeof(Platform.Xwa.FlightGroupCollection).ToString(); break;
+			}
+			if (collectionType != requiredType)
+				throw new ArgumentException("Invalid collection passed to FG Library");
+
+			_flightGroupCollection = flightGroupCollection;
+			_onAddEvent = onAddEvent;
+			resetDefaultLibrary();
+			loadLibrary(platform);
+			refreshGroupList();
+			refreshMissionCraft();
+			refreshLibraryCraft();
+			this.Show();
+		}
+
+		/// <summary>Returns the filename where the platform-specific library data is stored.</summary>
+		private string getLibraryFileName()
+		{
+			switch (_platform)
+			{
+				case Settings.Platform.XWING: return "fg_library_xw.bin";
+				case Settings.Platform.TIE: return "fg_library_tie.bin";
+				case Settings.Platform.XvT: case Settings.Platform.BoP: return "fg_library_xvt.bin";
+				case Settings.Platform.XWA: return "fg_library_xwa.bin";
+			}
+			return "";
+		}
+
+		/// <summary>Returns the full path and filename of the platform-specific library data.</summary>
+		private string getFullPath(string libraryFileName)
+		{
+			return Path.Combine(Directory.GetCurrentDirectory(), libraryFileName);
+		}
+
+		/// <summary>Activates a platform and loads its corresponding library data.</summary>
+		private void loadLibrary(Settings.Platform platform)
+		{
+			// Downgrade BoP so it can share the same library.
+			if (platform == Settings.Platform.BoP)
+				platform = Settings.Platform.XvT;
+
+			_platform = platform;
+
+			string label = "Tm - GG  - waves x craft (GU)";   // XvT, XWA
+			if (_platform == Settings.Platform.XWING) label = "IFF - waves x craft";
+			else if (_platform == Settings.Platform.TIE) label = "IFF - GG - waves x craft";
+			lblMissionCraft.Text = label;
+			lblLibraryCraft.Text = label;
+
+			string filename = getLibraryFileName();
+			if (filename == "")
+				return;
+
+			string path = getFullPath(filename);
+			if (File.Exists(path))
+			{
+				try
+				{
+					using (FileStream fs = new FileStream(path, FileMode.Open))
+					{
+						using (BinaryReader br = new BinaryReader(fs))
+						{
+							loadLibraryFromStream(fs, br);
+						}
+					}
+				}
+				catch (Exception x)
+				{
+					MessageBox.Show("Error loading FG library!" + Environment.NewLine + x.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				}
+			}
+		}
+
+		/// <summary>Loads the contents of a library from an open file stream.</summary>
+		private void loadLibraryFromStream(FileStream fs, BinaryReader br)
+		{
+			try
+			{
+				int fileId = br.ReadInt32();
+				int fileVersion = br.ReadInt32();
+				int filePlatform = br.ReadInt32();
+				if (fileId != LibraryHeaderId || fileVersion != LibraryVersion || filePlatform != (int)_platform)
+					return;
+
+				List<object> group = _groupList[0];
+				int groupCount = br.ReadInt32();
+				for (int i = 0; i < groupCount; i++)
+				{
+					string groupName = br.ReadString();
+					if (i > 0)
+					{
+						_groupNames.Add(groupName);
+						group = new List<object>();
+					}
+					int craftCount = br.ReadInt32();
+					br.ReadInt32(); // Reserved for future expansion data if needed.
+					for (int j = 0; j < craftCount; j++)
+					{
+						System.Runtime.Serialization.IFormatter formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+						object fg = formatter.Deserialize(fs);
+						group.Add(fg);
+					}
+					if (i > 0)
+						_groupList.Add(group);
+				}
+			}
+			catch (Exception) { /* do nothing */ }
+		}
+
+		/// <summary>Opens a platform-specific library file and writes the entire library into it.</summary>
+		private void saveLibrary()
+		{
+			string filename = getFullPath(getLibraryFileName());
+			try
+			{
+				using (FileStream fs = new FileStream(filename, FileMode.OpenOrCreate))
+				{
+					using (BinaryWriter br = new BinaryWriter(fs))
+					{
+						br.Write(LibraryHeaderId);
+						br.Write(LibraryVersion);
+						br.Write((int)_platform);
+						br.Write(_groupList.Count);
+						for (int i = 0; i < _groupList.Count; i++)
+						{
+							br.Write(_groupNames[i]);
+							br.Write(_groupList[i].Count);
+							br.Write((int)0);  // Reserved for future expansion data if needed.
+							for (int j = 0; j < _groupList[i].Count; j++)
+							{
+								System.Runtime.Serialization.IFormatter formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+								formatter.Serialize(fs, _groupList[i][j]);
+							}
+						}
+					}
+				}
+			}
+			catch (Exception x)
+			{
+				MessageBox.Show("Unable to save FG library!" + Environment.NewLine + x.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			}
+		}
+
+		/// <summary>Initializes and resets a library to its default empty state.</summary>
+		private void resetDefaultLibrary()
+		{
+			_groupList = new List<List<object>>();
+			_groupList.Add(new List<object>());
+
+			_groupNames = new List<string>();
+			_groupNames.Add("Default");
+
+			_craftProblems = new List<List<string>>();
+		}
+
+		/// <summary>Returns a string containing the group name and its number of items.</summary>
+		private string getGroupName(int group)
+		{
+			if (group < 0 || group >= _groupList.Count)
+				return "";
+			return _groupNames[group] + "  (" + _groupList[group].Count + ")";
+		}
+
+		/// <summary>Refreshes the list of library groups contained within the library.</summary>
+		private void refreshGroupList()
+		{
+			if(_groupNames.Count < 1 || _groupList.Count < 1)
+				resetDefaultLibrary();
+
+			if (_groupNames[0] != "Default")
+				_groupNames[0] = "Default";
+
+			int prevSelection = lstLibraryGroup.SelectedIndex;
+			if (prevSelection == -1)
+				prevSelection = 0;
+
+			lstLibraryGroup.Items.Clear();
+			cboLibraryGroup.Items.Clear();
+			for (int i = 0; i < _groupNames.Count; i++)
+			{
+				lstLibraryGroup.Items.Add(getGroupName(i));
+				cboLibraryGroup.Items.Add(getGroupName(i));
+			}
+			lstLibraryGroup.SelectedIndex = prevSelection;
+			if (cboLibraryGroup.SelectedIndex == -1)
+				cboLibraryGroup.SelectedIndex = 0;
+		}
+
+		/// <summary>Refreshes the visible craft count in the group listing.</summary>
+		private void refreshGroupCraftCount()
+		{
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupList.Count)
+				return;
+			lstLibraryGroup.Items[group] = getGroupName(group);
+			cboLibraryGroup.Items[group] = getGroupName(group);
+		}
+
+		/// <summary>Refreshes the contents of the mission craft list.</summary>
+		private void refreshMissionCraft()
+		{
+			lstMissionCraft.Items.Clear();
+			switch (_platform)
+			{
+				case Settings.Platform.XWING:
+					foreach (Platform.Xwing.FlightGroup fg in (Platform.Xwing.FlightGroupCollection)_flightGroupCollection)
+						lstMissionCraft.Items.Add(fg.ToString(true));
+					break;
+				case Settings.Platform.TIE:
+					foreach (Platform.Tie.FlightGroup fg in (Platform.Tie.FlightGroupCollection)_flightGroupCollection)
+						lstMissionCraft.Items.Add(fg.ToString(true));
+					break;
+				case Settings.Platform.XvT:
+				case Settings.Platform.BoP:
+					foreach (Platform.Xvt.FlightGroup fg in (Platform.Xvt.FlightGroupCollection)_flightGroupCollection)
+						lstMissionCraft.Items.Add(fg.ToString(true));
+					break;
+				case Settings.Platform.XWA:
+					foreach (Platform.Xwa.FlightGroup fg in (Platform.Xwa.FlightGroupCollection)_flightGroupCollection)
+						lstMissionCraft.Items.Add(fg.ToString(true));
+					break;
+			}
+		}
+
+		/// <summary>Refreshes the contents of the craft list of the selected library group.</summary>
+		private void refreshLibraryCraft()
+		{
+			lstLibraryCraft.Items.Clear();
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupList.Count)
+				return;
+			for (int i = 0; i < _groupList[group].Count; i++)
+				lstLibraryCraft.Items.Add(getFlightGroupString(_groupList[group][i]));
+			refreshProblems();
+		}
+
+		/// <summary>Returns the craft string as it would appear in the FlightGroup list.</summary>
+		private string getFlightGroupString(object fg)
+		{
+			try
+			{
+				switch (_platform)
+				{
+					case Settings.Platform.XWING: return ((Platform.Xwing.FlightGroup)fg).ToString(true);
+					case Settings.Platform.TIE: return ((Platform.Tie.FlightGroup)fg).ToString(true);
+					case Settings.Platform.XvT: case Settings.Platform.BoP: return ((Platform.Xvt.FlightGroup)fg).ToString(true);
+					case Settings.Platform.XWA: return ((Platform.Xwa.FlightGroup)fg).ToString(true);
+				}
+			} catch (Exception) { /* do nothing */ }
+			return "(invalid)";
+		}
+
+		/// <summary>Retrieves a generic object from within the platform-specific FlightGroupCollection.</summary>
+		private object getFlightGroupObjectFromCollection(int index)
+		{
+			switch (_platform)
+			{
+				case Settings.Platform.XWING: return ((Platform.Xwing.FlightGroupCollection)_flightGroupCollection)[index];
+				case Settings.Platform.TIE: return ((Platform.Tie.FlightGroupCollection)_flightGroupCollection)[index];
+				case Settings.Platform.XvT: case Settings.Platform.BoP: return ((Platform.Xvt.FlightGroupCollection)_flightGroupCollection)[index];
+				case Settings.Platform.XWA: return ((Platform.Xwa.FlightGroupCollection)_flightGroupCollection)[index];
+			}
+			return "";
+		}
+
+		/// <summary>Retrieves the IFF color to draw an item in the craft lists.</summary>
+		/// <remarks>This code is adapted from the getFlightGroupDrawColor() functions of each platform.</remarks>
+		Brush getFlightGroupDrawColor(object fg)
+		{
+			Brush brText = SystemBrushes.ControlText;
+			Brush[] xwingColors = { Brushes.DodgerBlue, Brushes.Lime, Brushes.Red, Brushes.DodgerBlue, Brushes.RoyalBlue };
+			Brush[] tieColors = { Brushes.Lime, Brushes.Red, Brushes.DodgerBlue, Brushes.MediumOrchid, Brushes.OrangeRed, Brushes.DarkOrchid };
+			Brush[] xvtxwaColors = { Brushes.Lime, Brushes.Red, Brushes.DodgerBlue, Brushes.Yellow, Brushes.OrangeRed, Brushes.MediumOrchid };
+
+			int iff = 0;
+			switch (_platform)
+			{
+				case Settings.Platform.XWING:
+					brText = Brushes.White; // Default to white for objects
+					if (((Platform.Xwing.FlightGroup)fg).IsFlightGroup())
+					{
+						iff = ((Platform.Xwing.FlightGroup)fg).GetActualIFF();
+						brText = (iff <= 4 ? xwingColors[iff] : SystemBrushes.ControlText);
+					}
+					break;
+				case Settings.Platform.TIE:
+					iff = ((Platform.Tie.FlightGroup)fg).IFF;
+					if (iff <= 5) brText = tieColors[iff];
+					if(((Platform.Tie.FlightGroup)fg).Difficulty == 6) brText = Brushes.Gray;
+					break;
+				case Settings.Platform.XvT:
+				case Settings.Platform.BoP:
+					iff = ((Platform.Xvt.FlightGroup)fg).IFF;
+					if (iff <= 5) brText = xvtxwaColors[iff];
+					if (((Platform.Xvt.FlightGroup)fg).Difficulty == 6 || ((Platform.Xvt.FlightGroup)fg).Difficulty == 7) brText = Brushes.Gray;
+					break;
+				case Settings.Platform.XWA:
+					iff = ((Platform.Xwa.FlightGroup)fg).IFF;
+					if (iff <= 5) brText = xvtxwaColors[iff];
+					if (((Platform.Xwa.FlightGroup)fg).Difficulty == 6) brText = Brushes.Gray;
+					break;
+			}
+			return brText;
+		}
+
+		/// <summary>Deletes the selected library craft from the group.</summary>
+		private void deleteLibraryCraftSelection()
+		{
+			// [JB] I tried adding a keypress handler for delete, but this caused all sorts of weird problems.  Possibly event race conditions with drag selection.
+			ListBox.SelectedIndexCollection sic = lstLibraryCraft.SelectedIndices;
+			int group = lstLibraryGroup.SelectedIndex;
+			if (sic.Count > 0 && group >= 0 && group < _groupList.Count)
+			{
+				while(sic.Count > 0)
+				{
+					int index = sic[sic.Count - 1];
+					_groupList[group].RemoveAt(index);
+					lstLibraryCraft.Items.RemoveAt(index); // Removing will modify the selected collection too.
+				}
+				_isDirty = true;
+			}
+			// There are some weird anomalies if deleting while a mouse-drag is in progress, where the underlying selection data doesn't correspond to what the user actually sees.
+			// This doesn't entirely solve the problem, but it helps.  Keeping this just to be safe.
+			lstLibraryCraft.Enabled = false;
+			for (int i = 0; i < lstLibraryCraft.Items.Count; i++)
+				if (lstLibraryCraft.GetSelected(i))
+					lstLibraryCraft.SetSelected(i, false);
+			lstLibraryCraft.Enabled = true;
+
+			refreshGroupCraftCount();
+		}
+
+		/// <summary>Resolves the target craft name of an FG index within the mission collection.</summary>
+		private string getProblemTargetName(int index)
+		{
+			if (index >= 0 && index < lstMissionCraft.Items.Count)
+			{
+				object targ = getFlightGroupObjectFromCollection(index);
+				if (targ.GetType().ToString().Contains("FlightGroup"))
+					return "[#" + (index + 1).ToString() + ": " + ((Platform.BaseFlightGroup)getFlightGroupObjectFromCollection(index)).ToString() + "]";
+			}
+			return "[#" + (index + 1).ToString() + " out of range]";
+		}
+
+		/// <summary>Adds a new problem string to a list of problems.</summary>
+		private void logProblem(string problem, List<string> output)
+		{
+			if (output == null)
+				return;
+
+			if (problem.Contains("FG:"))
+			{
+				int index = Common.ParseIntAfter(problem, "FG:");
+				string target = getProblemTargetName(index);
+				problem = problem.Replace("FG:" + index, target);
+			}
+			output.Add("  " + problem);
+		}
+
+		/// <summary>Scans a BaseFlightGroup's arrival/departure motherships for FG reference problems.</summary>
+		private void scanMothershipProblems(Platform.BaseFlightGroup bfg, bool scrubProblems, List<string> output)
+		{
+			if (bfg.ArrivalMethod1)
+			{
+				logProblem("Arrival mothership is FG:" + bfg.ArrivalCraft1, output);
+				if (scrubProblems) { bfg.ArrivalMethod1 = false; bfg.ArrivalCraft1 = 0; }
+			}
+			if (bfg.ArrivalMethod2)
+			{
+				logProblem("Alternate Arrival mothership is FG:" + bfg.ArrivalCraft2, output);
+				if (scrubProblems) { bfg.ArrivalMethod2 = false; bfg.ArrivalCraft2 = 0; }
+			}
+			if (bfg.DepartureMethod1)
+			{
+				logProblem("Departure mothership is FG:" + bfg.DepartureCraft1, output);
+				if (scrubProblems) { bfg.DepartureMethod1 = false; bfg.DepartureCraft1 = 0; }
+			}
+			if (bfg.DepartureMethod2)
+			{
+				logProblem("Alternate Departure mothership is FG:" + bfg.DepartureCraft2, output);
+				if (scrubProblems) { bfg.DepartureMethod2 = false; bfg.DepartureCraft2 = 0; }
+			}
+		}
+
+		/// <summary>Checks FlightGroup for potential issues caused by explicit FlightGroup reference indices that may cause unintended behavior when added into the mission.</summary>
+		/// <remarks>Checks mothership arrival/departure, all triggers and skip triggers, and orders.</remarks>
+		/// <param name="fg">FlightGroup object to check.</param>
+		/// <param name="scrubProblems">If true, if any FlightGroup references are detected or used in triggers, they will be replaced with null values.</param>
+		/// <param name="compileProblems">If true, specifies that a list strings will be returned, detailing all FlightGroup references used by this FlightGroup.</param>
+		/// <returns>Returns null if <b>compileProblems</b> is false. Otherwise returns a list of strings.</returns>
+		private List<string> scanProblems(object fg, bool scrubProblems, bool compileProblems)
+		{
+			List<string> errors = (compileProblems ? new List<string>() : null);
+			Platform.BaseFlightGroup bfg = (Platform.BaseFlightGroup)fg;
+			// Begin the list with a craft name indicating the object we're checking.
+			if(errors != null)
+				errors.Add(bfg.ToString());
+			switch (_platform)
+			{
+				case Settings.Platform.XWING:
+					Platform.Xwing.FlightGroup xwing = (Platform.Xwing.FlightGroup)fg;
+					if (xwing.Mothership >= 0)
+					{
+						if (xwing.ArrivalHyperspace == 0)
+						{
+							logProblem("Arrival mothership is FG:" + xwing.Mothership, errors);
+							if (scrubProblems) xwing.ArrivalHyperspace = 1;
+						}
+						if (xwing.DepartureHyperspace == 0)
+						{
+							logProblem("Departure mothership is FG:" + xwing.Mothership, errors);
+							if (scrubProblems) xwing.DepartureHyperspace = 1;
+						}
+						if (scrubProblems) xwing.Mothership = -1;
+					}
+					if (xwing.ArrivalFG >= 0)
+					{
+						logProblem("Arrival trigger is FG:" + xwing.ArrivalFG, errors);
+						if (scrubProblems)
+						{
+							xwing.ArrivalFG = -1;
+							xwing.ArrivalEvent = 0;
+						}
+					}
+					if (xwing.TargetPrimary >= 0)
+					{
+						logProblem("Primary target is FG:" + xwing.TargetPrimary, errors);
+						if (scrubProblems) xwing.TargetPrimary = -1;
+					}
+					if (xwing.TargetSecondary >= 0)
+					{
+						logProblem("Secondary target is FG:" + xwing.TargetSecondary, errors);
+						if (scrubProblems) xwing.TargetSecondary = -1;
+					}
+					break;
+				case Settings.Platform.TIE:
+					Platform.Tie.FlightGroup tie = (Platform.Tie.FlightGroup)fg;
+					scanMothershipProblems(tie, scrubProblems, errors);
+					for (int i = 0; i < tie.ArrDepTriggers.Length; i++)
+					{
+						Platform.Tie.Mission.Trigger trig = tie.ArrDepTriggers[i];
+						if (trig.Condition != 0 && trig.Condition != 10 && trig.VariableType == 1)
+						{
+							logProblem("ArrDep trigger #" + (i + 1) + " references FG:" + trig.Variable, errors);
+							if (scrubProblems) { trig.Condition = 0; trig.Variable = 0; trig.VariableType = 0; }
+						}
+					}
+					for (int i = 0; i < tie.Orders.Length; i++)
+					{
+						Platform.Tie.FlightGroup.Order order = tie.Orders[i];
+						if (order.Target1Type == 1) { logProblem("Order #" + (i + 1) + " Target1 references FG:" + order.Target1, errors); if (scrubProblems) { order.Target1 = 0; order.Target1Type = 0; } }
+						if (order.Target2Type == 1) { logProblem("Order #" + (i + 1) + " Target2 references FG:" + order.Target2, errors); if (scrubProblems) { order.Target2 = 0; order.Target2Type = 0; } }
+						if (order.Target3Type == 1) { logProblem("Order #" + (i + 1) + " Target3 references FG:" + order.Target3, errors); if (scrubProblems) { order.Target3 = 0; order.Target3Type = 0; } }
+						if (order.Target4Type == 1) { logProblem("Order #" + (i + 1) + " Target4 references FG:" + order.Target4, errors); if (scrubProblems) { order.Target4 = 0; order.Target4Type = 0; } }
+					}
+					break;
+				case Settings.Platform.XvT:
+				case Settings.Platform.BoP:
+					Platform.Xvt.FlightGroup xvt = (Platform.Xvt.FlightGroup)fg;
+					scanMothershipProblems(xvt, scrubProblems, errors);
+					for (int i = 0; i < xvt.ArrDepTriggers.Length; i++)
+					{
+						Platform.Xvt.Mission.Trigger trig = xvt.ArrDepTriggers[i];
+						if (trig.Condition != 0 && trig.Condition != 10 && (trig.VariableType == 1 || trig.VariableType == 0xF))
+						{
+							logProblem("ArrDep trigger #" + (i + 1) + " references FG:" + trig.Variable, errors);
+							if (scrubProblems) { trig.Condition = 0; trig.Variable = 0; trig.VariableType = 0; }
+						}
+					}
+					for (int i = 0; i < xvt.Orders.Length; i++)
+					{
+						Platform.Xvt.FlightGroup.Order order = xvt.Orders[i];
+						if (order.Target1Type == 1 || order.Target1Type == 0xF) { logProblem("Order #" + (i + 1) + " Target1 references FG:" + order.Target1, errors); if (scrubProblems) { order.Target1 = 0; order.Target1Type = 0; } }
+						if (order.Target2Type == 1 || order.Target2Type == 0xF) { logProblem("Order #" + (i + 1) + " Target2 references FG:" + order.Target2, errors); if (scrubProblems) { order.Target2 = 0; order.Target2Type = 0; } }
+						if (order.Target3Type == 1 || order.Target3Type == 0xF) { logProblem("Order #" + (i + 1) + " Target3 references FG:" + order.Target3, errors); if (scrubProblems) { order.Target3 = 0; order.Target3Type = 0; } }
+						if (order.Target4Type == 1 || order.Target4Type == 0xF) { logProblem("Order #" + (i + 1) + " Target4 references FG:" + order.Target4, errors); if (scrubProblems) { order.Target4 = 0; order.Target4Type = 0; } }
+					}
+					for (int i = 0; i < xvt.SkipToOrder4Trigger.Length; i++)
+					{
+						Platform.Xvt.Mission.Trigger trig = xvt.SkipToOrder4Trigger[i];
+						if (trig.Condition != 0 && trig.Condition != 10 && (trig.VariableType == 1 || trig.VariableType == 0xF))
+						{
+							logProblem("Skip trigger #" + (i + 1) + " references FG:" + trig.Variable, errors);
+							if (scrubProblems) { trig.Condition = 0; trig.Variable = 0; trig.VariableType = 0; }
+						}
+					}
+					break;
+				case Settings.Platform.XWA:
+					Platform.Xwa.FlightGroup xwa = (Platform.Xwa.FlightGroup)fg;
+					scanMothershipProblems(xwa, scrubProblems, errors);
+					for (int i = 0; i < xwa.ArrDepTriggers.Length; i++)
+					{
+						Platform.Xwa.Mission.Trigger trig = xwa.ArrDepTriggers[i];
+						if (trig.Condition != 0 && trig.Condition != 10 && (trig.VariableType == 1 || trig.VariableType == 0xF))
+						{
+							logProblem("ArrDep trigger #" + (i + 1) + " references FG:" + trig.Variable, errors);
+							if (scrubProblems) { trig.Condition = 0; trig.Variable = 0; trig.VariableType = 0; }
+						}
+						if (trig.Parameter1 > 4)
+						{
+							logProblem("ArrDep trigger #" + (i + 1) + " parameter references FG:" + trig.Parameter1, errors);
+							if (scrubProblems) { trig.Parameter1 = 0; }
+						}
+					}
+					for (int reg = 0; reg < 4; reg++)
+					{
+						for (int i = 0; i < 4; i++)
+						{
+							Platform.Xwa.FlightGroup.Order order = xwa.Orders[reg, i];
+							if (order.Target1Type == 1 || order.Target1Type == 0xF) { logProblem("Region #" + (reg + 1) + " Order #" + (i + 1) + " Target1 references FG:" + order.Target1, errors); if (scrubProblems) { order.Target1Type = 0; } }
+							if (order.Target2Type == 1 || order.Target2Type == 0xF) { logProblem("Region #" + (reg + 1) + " Order #" + (i + 1) + " Target2 references FG:" + order.Target2, errors); if (scrubProblems) { order.Target2Type = 0; } }
+							if (order.Target3Type == 1 || order.Target3Type == 0xF) { logProblem("Region #" + (reg + 1) + " Order #" + (i + 1) + " Target3 references FG:" + order.Target3, errors); if (scrubProblems) { order.Target3Type = 0; } }
+							if (order.Target4Type == 1 || order.Target4Type == 0xF) { logProblem("Region #" + (reg + 1) + " Order #" + (i + 1) + " Target4 references FG:" + order.Target4, errors); if (scrubProblems) { order.Target4Type = 0; } }
+							for (int k = 0; k < order.SkipTriggers.Length; k++)
+							{
+								Platform.Xwa.Mission.Trigger trig = order.SkipTriggers[k];
+								if (trig.Condition != 0 && trig.Condition != 10 && (trig.VariableType == 1 || trig.VariableType == 0xF))
+								{
+									logProblem("Region #" + (reg + 1) + " Order #" + (i + 1) + " Skip trigger #" + (k + 1) + " references FG:" + trig.Variable, errors);
+									if (scrubProblems) { trig.Condition = 0; trig.Variable = 0; trig.VariableType = 0; }
+								}
+								if (trig.Parameter1 > 4)
+								{
+									logProblem("Region #" + (reg + 1) + " Order #" + (i + 1) + " Skip trigger #" + (k + 1) + " parameter references FG:" + trig.Parameter1, errors);
+									if (scrubProblems) { trig.Parameter1 = 0; }
+								}
+							}
+						}
+					}
+					break;
+			}
+			
+			//Remove the name if no errors were logged.
+			if (errors != null && errors.Count == 1)
+				errors.Clear();
+			return errors;
+		}
+
+		/// <summary>Rebuilds the list of FG reference problems in the library craft list.</summary>
+		void refreshProblems()
+		{
+			_craftProblems.Clear();
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupList.Count)
+				return;
+			for(int i = 0; i < _groupList[group].Count; i++)
+				_craftProblems.Add(scanProblems(_groupList[group][i], false, true));
+			lstLibraryCraft.Refresh();
+		}
+
+		private void cmdNewGroup_Click(object sender, EventArgs e)
+		{
+			_groupList.Add(new List<object>());
+			string name = txtName.Text.Trim();
+			txtName.Text = "";
+			if(name == "")
+				name = "New Group";
+			_groupNames.Add(name);
+			refreshGroupList();
+			lstLibraryGroup.SelectedIndex = lstLibraryGroup.Items.Count - 1;
+			_isDirty = true;
+		}
+
+		private void cmdDeleteGroup_Click(object sender, EventArgs e)
+		{
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 1)
+			{
+				MessageBox.Show("You cannot delete the Default group. Delete its FlightGroup contents instead.", "Note");
+				return;
+			}
+			if (group >= _groupList.Count)
+				return;
+			if (_groupList[group].Count > 0)
+			{
+				DialogResult res = MessageBox.Show("Are you sure you want to delete the library group \"" + _groupNames[group] + "\" ?" + Environment.NewLine + "It contains " + _groupList[group].Count + " craft.", "Confirm", MessageBoxButtons.YesNo);
+				if (res != DialogResult.Yes)
+					return;
+			}
+			_groupList.RemoveAt(group);
+			if (group > _groupList.Count - 1)
+				group = _groupList.Count - 1;
+			lstLibraryGroup.SelectedIndex = group;
+			cboLibraryGroup.SelectedIndex = group;
+			refreshGroupList();
+			refreshLibraryCraft();
+			_isDirty = true;
+		}
+
+		private void cmdRenameGroup_Click(object sender, EventArgs e)
+		{
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupNames.Count)
+				return;
+			if (group == 0)
+			{
+				MessageBox.Show("You cannot rename the Default group.", "Note");
+				return;
+			}
+			string name = txtName.Text.Trim();
+			if (name == "")
+				return;
+			_groupNames[group] = name;
+			refreshGroupList();
+			txtName.Text = "";
+			_isDirty = true;
+		}
+
+		private void lstLibraryGroup_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			if (!_loading)
+				refreshLibraryCraft();
+		}
+
+		/// <summary>Adds all selected mission craft into the current library group.</summary>
+		private void cmdAddToLibrary_Click(object sender, EventArgs e)
+		{
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupList.Count)
+				return;
+			foreach (int si in lstMissionCraft.SelectedIndices)
+			{
+				using (MemoryStream ms = new MemoryStream(2048))
+				{
+					System.Runtime.Serialization.IFormatter formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+					formatter.Serialize(ms, getFlightGroupObjectFromCollection(si));
+					ms.Position = 0;
+					object fg = formatter.Deserialize(ms);
+
+					lstLibraryCraft.Items.Add(lstMissionCraft.Items[si]);
+					_groupList[group].Add(fg);
+					_isDirty = true;
+				}
+			}
+			refreshGroupCraftCount();
+		}
+
+		private void cmdAddToMission_Click(object sender, EventArgs e)
+		{
+			ListBox.SelectedIndexCollection sic = lstLibraryCraft.SelectedIndices;
+			if (sic.Count == 0)
+				return;
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupList.Count)
+				return;
+			object[] sendArray = new object[sic.Count];
+			int index = 0;
+			// Create an array of cloned objects to send back to the form.
+			foreach (int si in sic)
+			{
+				using (MemoryStream ms = new MemoryStream())
+				{
+					System.Runtime.Serialization.IFormatter formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+					formatter.Serialize(ms, _groupList[group][si]);
+					ms.Position = 0;
+					object fg = formatter.Deserialize(ms);
+					if (chkAutoscrubAddMission.Checked)
+						scanProblems(fg, true, false);
+					sendArray[index++] = fg;
+				}
+			}
+			_onAddEvent(sendArray, new EventArgs());
+		}
+
+		private void lstMissionCraft_DrawItem(object sender, DrawItemEventArgs e)
+		{
+			object fg = getFlightGroupObjectFromCollection(e.Index);
+			if (e.Index == -1 || fg.ToString() == "") return;
+			e.DrawBackground();
+			Brush brText = getFlightGroupDrawColor(fg); 
+			e.Graphics.DrawString(lstMissionCraft.Items[e.Index].ToString(), e.Font, brText, e.Bounds, StringFormat.GenericDefault);
+		}
+
+		private void lstGroupCraft_DrawItem(object sender, DrawItemEventArgs e)
+		{
+			Brush brText = SystemBrushes.ControlText;
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group >= 0 && group < _groupList.Count && e.Index >= 0 && e.Index < _groupList[group].Count)
+			{
+				object fg = _groupList[group][e.Index];
+				brText = getFlightGroupDrawColor(fg);
+				e.DrawBackground();
+				if (e.Index < _craftProblems.Count && _craftProblems[e.Index].Count > 0)
+				{
+					int height = e.Bounds.Bottom - e.Bounds.Top;
+					Rectangle r = new Rectangle(e.Bounds.Right - height - 5, e.Bounds.Top, height + 5, height);
+					e.Graphics.DrawString((_craftProblems[e.Index].Count - 1).ToString() + " !", e.Font, Brushes.Red, r, StringFormat.GenericDefault);
+				}
+				e.Graphics.DrawString(lstLibraryCraft.Items[e.Index].ToString(), e.Font, brText, e.Bounds, StringFormat.GenericDefault);
+			}
+		}
+
+		private void cmdMoveCraftUp_Click(object sender, EventArgs e)
+		{
+			ListBox.SelectedIndexCollection sic = lstLibraryCraft.SelectedIndices;
+			int group = lstLibraryGroup.SelectedIndex;
+			if (sic.Count == 0 || group < 0 || group >= _groupList.Count)
+				return;
+			int[] selection = new int[sic.Count];
+			for (int i = 0; i < sic.Count; i++)
+				selection[i] = sic[i];
+			if (selection[0] == 0)
+				return;
+			for (int i = 0; i < selection.Length; i++)
+			{
+				object temp = _groupList[group][selection[i] - 1];
+				_groupList[group][selection[i] - 1] = _groupList[group][selection[i]];
+				_groupList[group][selection[i]] = temp;
+			}
+			refreshLibraryCraft();
+			for (int i = 0; i < selection.Length; i++)
+				lstLibraryCraft.SetSelected(selection[i] - 1, true);
+			_isDirty = true;
+		}
+
+		private void cmdMoveCraftDown_Click(object sender, EventArgs e)
+		{
+			ListBox.SelectedIndexCollection sic = lstLibraryCraft.SelectedIndices;
+			int group = lstLibraryGroup.SelectedIndex;
+			if (sic.Count == 0 || group < 0 || group >= _groupList.Count)
+				return;
+			int[] selection = new int[sic.Count];
+			for (int i = 0; i < sic.Count; i++)
+				selection[i] = sic[i];
+			if (selection[selection.Length - 1] == lstLibraryCraft.Items.Count - 1)
+				return;
+			for (int i = selection.Length - 1; i >= 0; i--)
+			{
+				object temp = _groupList[group][selection[i] + 1];
+				_groupList[group][selection[i] + 1] = _groupList[group][selection[i]];
+				_groupList[group][selection[i]] = temp;
+			}
+			refreshLibraryCraft();
+			for (int i = 0; i < selection.Length; i++)
+				lstLibraryCraft.SetSelected(selection[i] + 1, true);
+			_isDirty = true;
+		}
+
+		private void cmdDeleteCraft_Click(object sender, EventArgs e)
+		{
+			deleteLibraryCraftSelection();
+		}
+
+		private void cmdMoveCraftToGroup_Click(object sender, EventArgs e)
+		{
+			ListBox.SelectedIndexCollection sic = lstLibraryCraft.SelectedIndices;
+			int srcGroup = lstLibraryGroup.SelectedIndex;
+			int dstGroup = cboLibraryGroup.SelectedIndex;
+			if (sic.Count == 0 || srcGroup < 0 || srcGroup >= _groupList.Count || dstGroup < 0 || dstGroup >= _groupList.Count)
+				return;
+			if (srcGroup == dstGroup)
+			{
+				MessageBox.Show("Already in this group.", "Note");
+				return;
+			}
+			for (int i = sic.Count - 1; i >= 0; i--)
+			{
+				_groupList[dstGroup].Add(_groupList[srcGroup][sic[i]]);
+				_groupList[srcGroup].RemoveAt(sic[i]);
+			}
+			refreshGroupList();
+			refreshLibraryCraft();
+			_isDirty = true;
+		}
+
+		private void FlightGroupLibraryForm_Activated(object sender, EventArgs e)
+		{
+			// The main editor form doesn't synchronize its changes with the FG Library.
+			// This automatically performs a refresh whenever the user switches focus to the library form.
+			refreshMissionCraft();
+			refreshProblems();
+		}
+
+		private void FlightGroupLibraryForm_SizeChanged(object sender, EventArgs e)
+		{
+			int height = grpCraftManager.Bottom - lstMissionCraft.Top;
+			if (this.ClientRectangle.Bottom > lstMissionCraft.Top + height)
+				height += this.ClientRectangle.Bottom - (lstMissionCraft.Top + height);
+			lstMissionCraft.Size = new Size(lstMissionCraft.Width, height);
+			lstLibraryCraft.Size = new Size(lstLibraryCraft.Width, height);
+		}
+
+		private void FlightGroupLibraryForm_FormClosing(object sender, FormClosingEventArgs e)
+		{
+			if (_isDirty)
+			{
+				saveLibrary();
+				_isDirty = false;
+			}
+		}
+
+		private void cmdViewProblems_Click(object sender, EventArgs e)
+		{
+			string text = "";
+			int count = 0;
+			foreach (int si in lstLibraryCraft.SelectedIndices)
+			{
+				if (count > 38)
+				{
+					text += Environment.NewLine + "Too many problems to list, select fewer craft.";
+					break;
+				}
+				if (text != "")
+					text += Environment.NewLine;
+				for(int i = 0; i < _craftProblems[si].Count; i++)
+				{
+					if (i > 0 && text != "")
+						text += Environment.NewLine;
+					text += _craftProblems[si][i];
+					count++;
+				}
+			}
+			if (text == "")
+				text = "No problems found.";
+			MessageBox.Show(text, "Possible FlightGroup reference problems");
+		}
+
+		private void cmdScrubProblems_Click(object sender, EventArgs e)
+		{
+			int group = lstLibraryGroup.SelectedIndex;
+			if (group < 0 || group >= _groupList.Count)
+				return;
+			foreach (int si in lstLibraryCraft.SelectedIndices)
+			{
+				if (si >= 0 && si < _groupList[group].Count)
+					scanProblems(_groupList[group][si], true, false);
+			}
+			refreshProblems();
+			_isDirty = true;
+		}
+	}
+}

--- a/FlightGroupLibraryForm.resx
+++ b/FlightGroupLibraryForm.resx
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAICAQAAAAAADoAgAAFgAAACgAAAAgAAAAQAAAAAEABAAAAAAAAAIAAAAAAAAAAAAAEAAAABAA
+        AAAAAAAAQEBAAACAAAAAgIAAgAAAAIAAgACAgAAAX19fAHBwcAAAAP8AAP8AAAD//wD/AAAA/wD/AP//
+        AAD///8AAAAAAAAAAId4AAAAAAAAAAAAAAAAAAB3dwAAAAAAAAAAAAAAAAAAd3cAAAAAAAAAAAAAAAAB
+        CHd3gBAAAAAAAAAAAAABAAdwB3AAEAAAAAAAAAAAAAAHcAdwAAAAAAAAAAAAAAAQB3AHcAEAAAAAAAAA
+        AAAAAAdwB3AAAAAAAAAAAAAAAAB3cAd3AAAAAAAAAAAQAACHd3AHd3gAAAEAAAAAABAId3AAAAd3gAEA
+        AAAAAQAAB3cAAAAAd3AAABAAAAAAAHdwAAAAAAd3AAAAAAAId3d3AAAQAQAAd3d3gACHd3d3dwABAAAQ
+        AHd3d3d4d3cAAAAAAAAAAAAAAAB3d3d3AAAAAAAAAAAAAAAAd3eHd3d3dwABAAAQAHd3d3d4AAh3d3cA
+        ABABAAB3d3eAAAAAAAB3cAAAAAAHdwAAAAAAAQAAB3cAAAAAd3AAABAAAAAAEAh3cAAAB3eAAQAAAAAA
+        EAAAh3dwB3d4AAABAAAAAAAAAAB3cAd3AAAAAAAAAAAAAAAAB3AHcAAAAAAAAAAAAAAAEAdwB3ABAAAA
+        AAAAAAAAAAAHcAdwAAAAAAAAAAAAAAEAB3AHcAAQAAAAAAAAAAAAAQh3d4AQAAAAAAAAAAAAAAAAd3cA
+        AAAAAAAAAAAAAAAAAHd3AAAAAAAAAAAAAAAAAACHeAAAAAAAAAD//D////w////8P///6Bf//4mR//8J
+        kP/+GZh//HmeP/jxjx/xwYOP8Yfhj+OP8cf/H/j/4Dw8BwA4HAAP+B/wD/gf8AA4HADgPDwH/x/4/+OP
+        8cfxh+GP8cGDj/jxjx/8eZ4//hmYf/8JkP//iZH//+gX///8P////D////w//w==
+</value>
+  </data>
+</root>

--- a/TieForm.Designer.cs
+++ b/TieForm.Designer.cs
@@ -408,6 +408,7 @@ namespace Idmr.Yogeme
 			this.savTIE = new System.Windows.Forms.SaveFileDialog();
 			this.dataWaypoints = new System.Data.DataView();
 			this.dataWaypointsRaw = new System.Data.DataView();
+			this.menuLibrary = new System.Windows.Forms.MenuItem();
 			this.tabMain.SuspendLayout();
 			this.tabFG.SuspendLayout();
 			this.tabFGMinor.SuspendLayout();
@@ -4308,7 +4309,8 @@ namespace Idmr.Yogeme
             this.menuBriefing,
             this.menuBattle,
             this.menuOptions,
-            this.menuGoalSummary});
+            this.menuGoalSummary,
+            this.menuLibrary});
 			this.menuTools.Text = "&Tools";
 			// 
 			// menuVerify
@@ -4409,6 +4411,12 @@ namespace Idmr.Yogeme
 			// 
 			this.dataWaypointsRaw.AllowDelete = false;
 			this.dataWaypointsRaw.AllowNew = false;
+			// 
+			// menuLibrary
+			// 
+			this.menuLibrary.Index = 6;
+			this.menuLibrary.Text = "FG Librar&y";
+			this.menuLibrary.Click += new System.EventHandler(this.menuLibrary_Click);
 			// 
 			// TieForm
 			// 
@@ -4906,5 +4914,6 @@ namespace Idmr.Yogeme
         private ComboBox cboSC1Color;
 		System.Data.DataView dataWaypoints;
 		System.Data.DataView dataWaypointsRaw;
+		private MenuItem menuLibrary;
 	}
 }

--- a/TieForm.cs
+++ b/TieForm.cs
@@ -121,6 +121,7 @@ namespace Idmr.Yogeme
 		readonly DataTable _tableRaw = new DataTable("Waypoints_Raw");
 		MapForm _fMap;
 		BriefingForm _fBrief;
+		FlightGroupLibraryForm _fLibrary;
 		BattleForm _fBattle;
 		OfficerPreviewForm _fOfficers;
 		byte _activeGlobalGoal;
@@ -179,6 +180,8 @@ namespace Idmr.Yogeme
 			try { _fBattle.Close(); }
 			catch { /* do nothing */ }
 			try { _fOfficers.Close(); }
+			catch { /* do nothing */ }
+			try { _fLibrary.Close(); }
 			catch { /* do nothing */ }
 		}
 		void comboVarRefresh(int index, ComboBox cbo)
@@ -1138,6 +1141,25 @@ namespace Idmr.Yogeme
 		void menuGoalSummary_Click(object sender, EventArgs e)
 		{
 			new GoalSummaryDialog("(global goals not included)\r\n\r\n" + generateGoalSummary()).Show();
+		}
+		void menuLibrary_Click(object sender, EventArgs e)
+		{
+			if (_fLibrary != null)
+				_fLibrary.Close();
+			_fLibrary = new FlightGroupLibraryForm(Settings.Platform.TIE, _mission.FlightGroups, flightGroupLibraryCallback);
+		}
+		void flightGroupLibraryCallback(object sender, EventArgs e)
+		{
+			foreach (FlightGroup fg in (object[])sender)
+			{
+				if (fg == null || !newFG())
+					break;
+				_mission.FlightGroups[_activeFG] = fg;
+				updateFGList();
+				listRefresh();
+				_startingShips--;
+				craftStart(fg, true);
+			}
 		}
 		void menuHelpInfo_Click(object sender, EventArgs e)
 		{

--- a/XvtForm.Designer.cs
+++ b/XvtForm.Designer.cs
@@ -156,6 +156,8 @@ namespace Idmr.Yogeme
 			this.label46 = new System.Windows.Forms.Label();
 			this.cmdPasteAD = new System.Windows.Forms.Button();
 			this.tabGoals = new System.Windows.Forms.TabPage();
+			this.label28 = new System.Windows.Forms.Label();
+			this.lstGoalTeams = new System.Windows.Forms.ListBox();
 			this.lblGoalTimeLimit = new System.Windows.Forms.Label();
 			this.label19 = new System.Windows.Forms.Label();
 			this.grpGoal = new System.Windows.Forms.GroupBox();
@@ -163,8 +165,6 @@ namespace Idmr.Yogeme
 			this.cboGoalAmount = new System.Windows.Forms.ComboBox();
 			this.cboGoalArgument = new System.Windows.Forms.ComboBox();
 			this.cboGoalTrigger = new System.Windows.Forms.ComboBox();
-			this.label66 = new System.Windows.Forms.Label();
-			this.chkGoalEnable = new System.Windows.Forms.CheckBox();
 			this.numGoalPoints = new System.Windows.Forms.NumericUpDown();
 			this.label65 = new System.Windows.Forms.Label();
 			this.label62 = new System.Windows.Forms.Label();
@@ -184,7 +184,6 @@ namespace Idmr.Yogeme
 			this.label63 = new System.Windows.Forms.Label();
 			this.label64 = new System.Windows.Forms.Label();
 			this.numGoalTimeLimit = new System.Windows.Forms.NumericUpDown();
-			this.numGoalTeam = new System.Windows.Forms.NumericUpDown();
 			this.tabWP = new System.Windows.Forms.TabPage();
 			this.label76 = new System.Windows.Forms.Label();
 			this.numRoll = new System.Windows.Forms.NumericUpDown();
@@ -359,17 +358,11 @@ namespace Idmr.Yogeme
 			this.label86 = new System.Windows.Forms.Label();
 			this.label85 = new System.Windows.Forms.Label();
 			this.grpUnkCraft = new System.Windows.Forms.GroupBox();
+			this.label27 = new System.Windows.Forms.Label();
 			this.numUnk1 = new System.Windows.Forms.NumericUpDown();
 			this.label83 = new System.Windows.Forms.Label();
 			this.grpUnkGoal = new System.Windows.Forms.GroupBox();
-			this.chkUnk10 = new System.Windows.Forms.CheckBox();
-			this.numUnkGoal = new System.Windows.Forms.NumericUpDown();
 			this.label92 = new System.Windows.Forms.Label();
-			this.numUnk13 = new System.Windows.Forms.NumericUpDown();
-			this.label95 = new System.Windows.Forms.Label();
-			this.chkUnk11 = new System.Windows.Forms.CheckBox();
-			this.chkUnk12 = new System.Windows.Forms.CheckBox();
-			this.chkUnk14 = new System.Windows.Forms.CheckBox();
 			this.label91 = new System.Windows.Forms.Label();
 			this.label1 = new System.Windows.Forms.Label();
 			this.lstFG = new System.Windows.Forms.ListBox();
@@ -612,7 +605,6 @@ namespace Idmr.Yogeme
 			this.savXvT = new System.Windows.Forms.SaveFileDialog();
 			this.dataWaypoints = new System.Data.DataView();
 			this.dataWaypoints_Raw = new System.Data.DataView();
-			this.label27 = new System.Windows.Forms.Label();
 			this.tabMain.SuspendLayout();
 			this.tabFG.SuspendLayout();
 			this.tabFGMinor.SuspendLayout();
@@ -650,7 +642,6 @@ namespace Idmr.Yogeme
 			((System.ComponentModel.ISupportInitialize)(this.numGoalPoints)).BeginInit();
 			this.groupBox16.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numGoalTimeLimit)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numGoalTeam)).BeginInit();
 			this.tabWP.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numRoll)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numPitch)).BeginInit();
@@ -689,8 +680,6 @@ namespace Idmr.Yogeme
 			this.grpUnkCraft.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numUnk1)).BeginInit();
 			this.grpUnkGoal.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numUnkGoal)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numUnk13)).BeginInit();
 			this.tabMess.SuspendLayout();
 			this.grpMessages.SuspendLayout();
 			this.panel8.SuspendLayout();
@@ -2184,11 +2173,11 @@ namespace Idmr.Yogeme
 			// 
 			// tabGoals
 			// 
+			this.tabGoals.Controls.Add(this.label28);
+			this.tabGoals.Controls.Add(this.lstGoalTeams);
 			this.tabGoals.Controls.Add(this.lblGoalTimeLimit);
 			this.tabGoals.Controls.Add(this.label19);
 			this.tabGoals.Controls.Add(this.grpGoal);
-			this.tabGoals.Controls.Add(this.label66);
-			this.tabGoals.Controls.Add(this.chkGoalEnable);
 			this.tabGoals.Controls.Add(this.numGoalPoints);
 			this.tabGoals.Controls.Add(this.label65);
 			this.tabGoals.Controls.Add(this.label62);
@@ -2200,12 +2189,32 @@ namespace Idmr.Yogeme
 			this.tabGoals.Controls.Add(this.label63);
 			this.tabGoals.Controls.Add(this.label64);
 			this.tabGoals.Controls.Add(this.numGoalTimeLimit);
-			this.tabGoals.Controls.Add(this.numGoalTeam);
 			this.tabGoals.Location = new System.Drawing.Point(4, 22);
 			this.tabGoals.Name = "tabGoals";
 			this.tabGoals.Size = new System.Drawing.Size(544, 478);
 			this.tabGoals.TabIndex = 2;
 			this.tabGoals.Text = "Goals";
+			// 
+			// label28
+			// 
+			this.label28.AutoSize = true;
+			this.label28.Location = new System.Drawing.Point(329, 261);
+			this.label28.Name = "label28";
+			this.label28.Size = new System.Drawing.Size(58, 13);
+			this.label28.TabIndex = 52;
+			this.label28.Text = "Enable for:";
+			this.label28.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// lstGoalTeams
+			// 
+			this.lstGoalTeams.ColumnWidth = 65;
+			this.lstGoalTeams.Location = new System.Drawing.Point(393, 261);
+			this.lstGoalTeams.MultiColumn = true;
+			this.lstGoalTeams.Name = "lstGoalTeams";
+			this.lstGoalTeams.SelectionMode = System.Windows.Forms.SelectionMode.MultiSimple;
+			this.lstGoalTeams.Size = new System.Drawing.Size(135, 69);
+			this.lstGoalTeams.TabIndex = 51;
+			this.lstGoalTeams.SelectedIndexChanged += new System.EventHandler(this.lstGoalTeams_SelectedIndexChanged);
 			// 
 			// lblGoalTimeLimit
 			// 
@@ -2276,26 +2285,6 @@ namespace Idmr.Yogeme
 			this.cboGoalTrigger.Size = new System.Drawing.Size(160, 21);
 			this.cboGoalTrigger.TabIndex = 41;
 			// 
-			// label66
-			// 
-			this.label66.AutoSize = true;
-			this.label66.Location = new System.Drawing.Point(359, 294);
-			this.label66.Name = "label66";
-			this.label66.Size = new System.Drawing.Size(111, 13);
-			this.label66.TabIndex = 47;
-			this.label66.Text = "Goal Applies to Team:";
-			// 
-			// chkGoalEnable
-			// 
-			this.chkGoalEnable.AutoSize = true;
-			this.chkGoalEnable.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkGoalEnable.Location = new System.Drawing.Point(379, 314);
-			this.chkGoalEnable.Name = "chkGoalEnable";
-			this.chkGoalEnable.Size = new System.Drawing.Size(119, 17);
-			this.chkGoalEnable.TabIndex = 46;
-			this.chkGoalEnable.Text = "Enabled for Team 1";
-			this.chkGoalEnable.CheckedChanged += new System.EventHandler(this.chkGoalEnable_CheckedChanged);
-			// 
 			// numGoalPoints
 			// 
 			this.numGoalPoints.Increment = new decimal(new int[] {
@@ -2303,7 +2292,7 @@ namespace Idmr.Yogeme
             0,
             0,
             0});
-			this.numGoalPoints.Location = new System.Drawing.Point(462, 264);
+			this.numGoalPoints.Location = new System.Drawing.Point(313, 310);
 			this.numGoalPoints.Maximum = new decimal(new int[] {
             31750,
             0,
@@ -2322,7 +2311,7 @@ namespace Idmr.Yogeme
 			// label65
 			// 
 			this.label65.AutoSize = true;
-			this.label65.Location = new System.Drawing.Point(417, 268);
+			this.label65.Location = new System.Drawing.Point(310, 294);
 			this.label65.Name = "label65";
 			this.label65.Size = new System.Drawing.Size(39, 13);
 			this.label65.TabIndex = 44;
@@ -2510,29 +2499,6 @@ namespace Idmr.Yogeme
 			this.numGoalTimeLimit.Size = new System.Drawing.Size(56, 20);
 			this.numGoalTimeLimit.TabIndex = 46;
 			this.numGoalTimeLimit.ValueChanged += new System.EventHandler(this.numGoalTimeLimit_ValueChanged);
-			// 
-			// numGoalTeam
-			// 
-			this.numGoalTeam.Location = new System.Drawing.Point(476, 290);
-			this.numGoalTeam.Maximum = new decimal(new int[] {
-            8,
-            0,
-            0,
-            0});
-			this.numGoalTeam.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-			this.numGoalTeam.Name = "numGoalTeam";
-			this.numGoalTeam.Size = new System.Drawing.Size(42, 20);
-			this.numGoalTeam.TabIndex = 45;
-			this.numGoalTeam.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-			this.numGoalTeam.Leave += new System.EventHandler(this.numGoalTeam_Leave);
 			// 
 			// tabWP
 			// 
@@ -4388,6 +4354,14 @@ namespace Idmr.Yogeme
 			this.grpUnkCraft.Text = "Craft";
 			this.grpUnkCraft.Leave += new System.EventHandler(this.grpUnkCraft_Leave);
 			// 
+			// label27
+			// 
+			this.label27.Location = new System.Drawing.Point(117, 24);
+			this.label27.Name = "label27";
+			this.label27.Size = new System.Drawing.Size(131, 23);
+			this.label27.TabIndex = 4;
+			this.label27.Text = "0x63 StopArrivingWhen";
+			// 
 			// numUnk1
 			// 
 			this.numUnk1.Location = new System.Drawing.Point(56, 22);
@@ -4411,14 +4385,7 @@ namespace Idmr.Yogeme
 			// 
 			// grpUnkGoal
 			// 
-			this.grpUnkGoal.Controls.Add(this.chkUnk10);
-			this.grpUnkGoal.Controls.Add(this.numUnkGoal);
 			this.grpUnkGoal.Controls.Add(this.label92);
-			this.grpUnkGoal.Controls.Add(this.numUnk13);
-			this.grpUnkGoal.Controls.Add(this.label95);
-			this.grpUnkGoal.Controls.Add(this.chkUnk11);
-			this.grpUnkGoal.Controls.Add(this.chkUnk12);
-			this.grpUnkGoal.Controls.Add(this.chkUnk14);
 			this.grpUnkGoal.Controls.Add(this.label91);
 			this.grpUnkGoal.Location = new System.Drawing.Point(8, 248);
 			this.grpUnkGoal.Name = "grpUnkGoal";
@@ -4426,97 +4393,15 @@ namespace Idmr.Yogeme
 			this.grpUnkGoal.TabIndex = 9;
 			this.grpUnkGoal.TabStop = false;
 			this.grpUnkGoal.Text = "Goals";
-			this.grpUnkGoal.Leave += new System.EventHandler(this.grpUnkGoal_Leave);
-			// 
-			// chkUnk10
-			// 
-			this.chkUnk10.Location = new System.Drawing.Point(8, 40);
-			this.chkUnk10.Name = "chkUnk10";
-			this.chkUnk10.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.chkUnk10.Size = new System.Drawing.Size(56, 32);
-			this.chkUnk10.TabIndex = 9;
-			this.chkUnk10.Text = "(0x6)";
-			// 
-			// numUnkGoal
-			// 
-			this.numUnkGoal.Location = new System.Drawing.Point(56, 16);
-			this.numUnkGoal.Maximum = new decimal(new int[] {
-            8,
-            0,
-            0,
-            0});
-			this.numUnkGoal.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-			this.numUnkGoal.Name = "numUnkGoal";
-			this.numUnkGoal.Size = new System.Drawing.Size(40, 20);
-			this.numUnkGoal.TabIndex = 6;
-			this.numUnkGoal.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-			this.numUnkGoal.ValueChanged += new System.EventHandler(this.numUnkGoal_ValueChanged);
-			this.numUnkGoal.Enter += new System.EventHandler(this.numUnkGoal_Enter);
 			// 
 			// label92
 			// 
-			this.label92.Location = new System.Drawing.Point(8, 16);
+			this.label92.Location = new System.Drawing.Point(26, 47);
 			this.label92.Name = "label92";
-			this.label92.Size = new System.Drawing.Size(40, 16);
+			this.label92.Size = new System.Drawing.Size(206, 16);
 			this.label92.TabIndex = 5;
-			this.label92.Text = "Goal";
+			this.label92.Text = "(0x6, 0x7, ... 0xD) EnabledForTeam";
 			this.label92.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
-			// 
-			// numUnk13
-			// 
-			this.numUnk13.Location = new System.Drawing.Point(224, 46);
-			this.numUnk13.Maximum = new decimal(new int[] {
-            256,
-            0,
-            0,
-            0});
-			this.numUnk13.Name = "numUnk13";
-			this.numUnk13.Size = new System.Drawing.Size(48, 20);
-			this.numUnk13.TabIndex = 7;
-			// 
-			// label95
-			// 
-			this.label95.Location = new System.Drawing.Point(176, 46);
-			this.label95.Name = "label95";
-			this.label95.Size = new System.Drawing.Size(40, 16);
-			this.label95.TabIndex = 8;
-			this.label95.Text = "(0xB)";
-			this.label95.TextAlign = System.Drawing.ContentAlignment.BottomRight;
-			// 
-			// chkUnk11
-			// 
-			this.chkUnk11.Location = new System.Drawing.Point(64, 40);
-			this.chkUnk11.Name = "chkUnk11";
-			this.chkUnk11.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.chkUnk11.Size = new System.Drawing.Size(56, 32);
-			this.chkUnk11.TabIndex = 9;
-			this.chkUnk11.Text = "(0x7)";
-			// 
-			// chkUnk12
-			// 
-			this.chkUnk12.Location = new System.Drawing.Point(120, 40);
-			this.chkUnk12.Name = "chkUnk12";
-			this.chkUnk12.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.chkUnk12.Size = new System.Drawing.Size(56, 32);
-			this.chkUnk12.TabIndex = 9;
-			this.chkUnk12.Text = "(0x8)";
-			// 
-			// chkUnk14
-			// 
-			this.chkUnk14.Location = new System.Drawing.Point(272, 40);
-			this.chkUnk14.Name = "chkUnk14";
-			this.chkUnk14.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.chkUnk14.Size = new System.Drawing.Size(56, 32);
-			this.chkUnk14.TabIndex = 9;
-			this.chkUnk14.Text = "(0xC)";
 			// 
 			// label91
 			// 
@@ -6833,14 +6718,6 @@ namespace Idmr.Yogeme
 			this.dataWaypoints_Raw.AllowDelete = false;
 			this.dataWaypoints_Raw.AllowNew = false;
 			// 
-			// label27
-			// 
-			this.label27.Location = new System.Drawing.Point(117, 24);
-			this.label27.Name = "label27";
-			this.label27.Size = new System.Drawing.Size(131, 23);
-			this.label27.TabIndex = 4;
-			this.label27.Text = "0x63 StopArrivingWhen";
-			// 
 			// XvtForm
 			// 
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
@@ -6900,7 +6777,6 @@ namespace Idmr.Yogeme
 			((System.ComponentModel.ISupportInitialize)(this.numGoalPoints)).EndInit();
 			this.groupBox16.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.numGoalTimeLimit)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numGoalTeam)).EndInit();
 			this.tabWP.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.numRoll)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numPitch)).EndInit();
@@ -6941,8 +6817,6 @@ namespace Idmr.Yogeme
 			this.grpUnkCraft.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.numUnk1)).EndInit();
 			this.grpUnkGoal.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.numUnkGoal)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numUnk13)).EndInit();
 			this.tabMess.ResumeLayout(false);
 			this.tabMess.PerformLayout();
 			this.grpMessages.ResumeLayout(false);
@@ -7093,14 +6967,6 @@ namespace Idmr.Yogeme
 		NumericUpDown numUnk9;
 		Label label90;
 		GroupBox grpUnkGoal;
-		NumericUpDown numUnkGoal;
-		Label label92;
-		NumericUpDown numUnk13;
-		Label label95;
-		CheckBox chkUnk10;
-		CheckBox chkUnk11;
-		CheckBox chkUnk12;
-		CheckBox chkUnk14;
 		Label label91;
 		GroupBox grpUnkOther;
 		CheckBox chkUnk17;
@@ -7165,9 +7031,6 @@ namespace Idmr.Yogeme
 		TextBox txtGoalFail;
 		Label label65;
 		NumericUpDown numGoalPoints;
-		CheckBox chkGoalEnable;
-		Label label66;
-		NumericUpDown numGoalTeam;
 		GroupBox grpGoal;
 		Label label67;
 		NumericUpDown numExplode;
@@ -7582,5 +7445,8 @@ namespace Idmr.Yogeme
 		private NumericUpDown numRandomArrivalDelaySeconds;
 		private GroupBox grpMoreArrival;
 		private Label label27;
+		private ListBox lstGoalTeams;
+		private Label label28;
+		private Label label92;
 	}
 }

--- a/XvtForm.Designer.cs
+++ b/XvtForm.Designer.cs
@@ -597,6 +597,7 @@ namespace Idmr.Yogeme
 			this.menuLST = new System.Windows.Forms.MenuItem();
 			this.menuOptions = new System.Windows.Forms.MenuItem();
 			this.menuGoalSummary = new System.Windows.Forms.MenuItem();
+			this.menuLibrary = new System.Windows.Forms.MenuItem();
 			this.menuTest = new System.Windows.Forms.MenuItem();
 			this.menuHelp = new System.Windows.Forms.MenuItem();
 			this.menuHelpInfo = new System.Windows.Forms.MenuItem();
@@ -6643,7 +6644,8 @@ namespace Idmr.Yogeme
             this.menuBrief,
             this.menuLST,
             this.menuOptions,
-            this.menuGoalSummary});
+            this.menuGoalSummary,
+            this.menuLibrary});
 			this.menuTools.Text = "&Tools";
 			// 
 			// menuVerify
@@ -6681,6 +6683,12 @@ namespace Idmr.Yogeme
 			this.menuGoalSummary.Index = 5;
 			this.menuGoalSummary.Text = "FG &Goal Summary";
 			this.menuGoalSummary.Click += new System.EventHandler(this.menuGoalSummary_Click);
+			// 
+			// menuLibrary
+			// 
+			this.menuLibrary.Index = 6;
+			this.menuLibrary.Text = "FG Librar&y";
+			this.menuLibrary.Click += new System.EventHandler(this.menuLibrary_Click);
 			// 
 			// menuTest
 			// 
@@ -7476,6 +7484,7 @@ namespace Idmr.Yogeme
 		private ListBox lstGoalTeams;
 		private Label label28;
 		private Label label92;
+		private MenuItem menuLibrary;
 		private NumericUpDown numRndSeed;
 		private Label label29;
 	}

--- a/XvtForm.Designer.cs
+++ b/XvtForm.Designer.cs
@@ -318,8 +318,18 @@ namespace Idmr.Yogeme
 			this.chkOptWAdvTorp = new System.Windows.Forms.CheckBox();
 			this.chkOptWMagPulse = new System.Windows.Forms.CheckBox();
 			this.chkOptWIonPulse = new System.Windows.Forms.CheckBox();
+			this.tabArrDep2 = new System.Windows.Forms.TabPage();
+			this.grpMoreArrival = new System.Windows.Forms.GroupBox();
+			this.numRandomArrivalDelayMinutes = new System.Windows.Forms.NumericUpDown();
+			this.numRandomArrivalDelaySeconds = new System.Windows.Forms.NumericUpDown();
+			this.lblRandomArrivalDelayMinutes = new System.Windows.Forms.Label();
+			this.lblRandomArrivalDelaySeconds = new System.Windows.Forms.Label();
+			this.lblRandomArrivalDelayDesc = new System.Windows.Forms.Label();
+			this.cboStopArrivingWhen = new System.Windows.Forms.ComboBox();
+			this.lblStopArrivingWhen = new System.Windows.Forms.Label();
 			this.tabUnk = new System.Windows.Forms.TabPage();
 			this.grpUnkOther = new System.Windows.Forms.GroupBox();
+			this.label26 = new System.Windows.Forms.Label();
 			this.label93 = new System.Windows.Forms.Label();
 			this.chkUnk17 = new System.Windows.Forms.CheckBox();
 			this.chkUnk18 = new System.Windows.Forms.CheckBox();
@@ -346,14 +356,11 @@ namespace Idmr.Yogeme
 			this.grpUnkAD = new System.Windows.Forms.GroupBox();
 			this.numUnk5 = new System.Windows.Forms.NumericUpDown();
 			this.label87 = new System.Windows.Forms.Label();
-			this.numUnk4 = new System.Windows.Forms.NumericUpDown();
 			this.label86 = new System.Windows.Forms.Label();
-			this.numUnk3 = new System.Windows.Forms.NumericUpDown();
 			this.label85 = new System.Windows.Forms.Label();
 			this.grpUnkCraft = new System.Windows.Forms.GroupBox();
 			this.numUnk1 = new System.Windows.Forms.NumericUpDown();
 			this.label83 = new System.Windows.Forms.Label();
-			this.chkUnk2 = new System.Windows.Forms.CheckBox();
 			this.grpUnkGoal = new System.Windows.Forms.GroupBox();
 			this.chkUnk10 = new System.Windows.Forms.CheckBox();
 			this.numUnkGoal = new System.Windows.Forms.NumericUpDown();
@@ -605,7 +612,7 @@ namespace Idmr.Yogeme
 			this.savXvT = new System.Windows.Forms.SaveFileDialog();
 			this.dataWaypoints = new System.Data.DataView();
 			this.dataWaypoints_Raw = new System.Data.DataView();
-			this.label26 = new System.Windows.Forms.Label();
+			this.label27 = new System.Windows.Forms.Label();
 			this.tabMain.SuspendLayout();
 			this.tabFG.SuspendLayout();
 			this.tabFGMinor.SuspendLayout();
@@ -665,6 +672,10 @@ namespace Idmr.Yogeme
 			this.groupBox21.SuspendLayout();
 			this.groupBox20.SuspendLayout();
 			this.groupBox19.SuspendLayout();
+			this.tabArrDep2.SuspendLayout();
+			this.grpMoreArrival.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numRandomArrivalDelayMinutes)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numRandomArrivalDelaySeconds)).BeginInit();
 			this.tabUnk.SuspendLayout();
 			this.grpUnkOther.SuspendLayout();
 			this.grpUnkOrder.SuspendLayout();
@@ -675,8 +686,6 @@ namespace Idmr.Yogeme
 			((System.ComponentModel.ISupportInitialize)(this.numUnk9)).BeginInit();
 			this.grpUnkAD.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numUnk5)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numUnk4)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numUnk3)).BeginInit();
 			this.grpUnkCraft.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numUnk1)).BeginInit();
 			this.grpUnkGoal.SuspendLayout();
@@ -750,6 +759,7 @@ namespace Idmr.Yogeme
 			this.tabFGMinor.Controls.Add(this.tabWP);
 			this.tabFGMinor.Controls.Add(this.tabOrders);
 			this.tabFGMinor.Controls.Add(this.tapOption);
+			this.tabFGMinor.Controls.Add(this.tabArrDep2);
 			this.tabFGMinor.Controls.Add(this.tabUnk);
 			this.tabFGMinor.Location = new System.Drawing.Point(232, 0);
 			this.tabFGMinor.Name = "tabFGMinor";
@@ -3927,6 +3937,106 @@ namespace Idmr.Yogeme
 			this.chkOptWIonPulse.TabIndex = 0;
 			this.chkOptWIonPulse.Text = "(Ion Pulse)";
 			// 
+			// tabArrDep2
+			// 
+			this.tabArrDep2.Controls.Add(this.grpMoreArrival);
+			this.tabArrDep2.Location = new System.Drawing.Point(4, 22);
+			this.tabArrDep2.Name = "tabArrDep2";
+			this.tabArrDep2.Padding = new System.Windows.Forms.Padding(3);
+			this.tabArrDep2.Size = new System.Drawing.Size(544, 478);
+			this.tabArrDep2.TabIndex = 7;
+			this.tabArrDep2.Text = "More Arr/Dep";
+			this.tabArrDep2.UseVisualStyleBackColor = true;
+			// 
+			// grpMoreArrival
+			// 
+			this.grpMoreArrival.Controls.Add(this.numRandomArrivalDelayMinutes);
+			this.grpMoreArrival.Controls.Add(this.numRandomArrivalDelaySeconds);
+			this.grpMoreArrival.Controls.Add(this.lblRandomArrivalDelayMinutes);
+			this.grpMoreArrival.Controls.Add(this.lblRandomArrivalDelaySeconds);
+			this.grpMoreArrival.Controls.Add(this.lblRandomArrivalDelayDesc);
+			this.grpMoreArrival.Controls.Add(this.cboStopArrivingWhen);
+			this.grpMoreArrival.Controls.Add(this.lblStopArrivingWhen);
+			this.grpMoreArrival.Location = new System.Drawing.Point(9, 10);
+			this.grpMoreArrival.Name = "grpMoreArrival";
+			this.grpMoreArrival.Size = new System.Drawing.Size(515, 143);
+			this.grpMoreArrival.TabIndex = 4;
+			this.grpMoreArrival.TabStop = false;
+			this.grpMoreArrival.Text = "Arrival";
+			this.grpMoreArrival.Leave += new System.EventHandler(this.grpMoreArrival_Leave);
+			// 
+			// numRandomArrivalDelayMinutes
+			// 
+			this.numRandomArrivalDelayMinutes.Location = new System.Drawing.Point(34, 110);
+			this.numRandomArrivalDelayMinutes.Margin = new System.Windows.Forms.Padding(3, 3, 1, 3);
+			this.numRandomArrivalDelayMinutes.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+			this.numRandomArrivalDelayMinutes.Name = "numRandomArrivalDelayMinutes";
+			this.numRandomArrivalDelayMinutes.Size = new System.Drawing.Size(42, 20);
+			this.numRandomArrivalDelayMinutes.TabIndex = 3;
+			// 
+			// numRandomArrivalDelaySeconds
+			// 
+			this.numRandomArrivalDelaySeconds.Location = new System.Drawing.Point(126, 110);
+			this.numRandomArrivalDelaySeconds.Margin = new System.Windows.Forms.Padding(3, 3, 1, 3);
+			this.numRandomArrivalDelaySeconds.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+			this.numRandomArrivalDelaySeconds.Name = "numRandomArrivalDelaySeconds";
+			this.numRandomArrivalDelaySeconds.Size = new System.Drawing.Size(42, 20);
+			this.numRandomArrivalDelaySeconds.TabIndex = 2;
+			// 
+			// lblRandomArrivalDelayMinutes
+			// 
+			this.lblRandomArrivalDelayMinutes.AutoSize = true;
+			this.lblRandomArrivalDelayMinutes.Location = new System.Drawing.Point(78, 112);
+			this.lblRandomArrivalDelayMinutes.Margin = new System.Windows.Forms.Padding(1, 0, 3, 0);
+			this.lblRandomArrivalDelayMinutes.Name = "lblRandomArrivalDelayMinutes";
+			this.lblRandomArrivalDelayMinutes.Size = new System.Drawing.Size(24, 13);
+			this.lblRandomArrivalDelayMinutes.TabIndex = 3;
+			this.lblRandomArrivalDelayMinutes.Text = "Min";
+			// 
+			// lblRandomArrivalDelaySeconds
+			// 
+			this.lblRandomArrivalDelaySeconds.AutoSize = true;
+			this.lblRandomArrivalDelaySeconds.Location = new System.Drawing.Point(170, 112);
+			this.lblRandomArrivalDelaySeconds.Margin = new System.Windows.Forms.Padding(1, 0, 3, 0);
+			this.lblRandomArrivalDelaySeconds.Name = "lblRandomArrivalDelaySeconds";
+			this.lblRandomArrivalDelaySeconds.Size = new System.Drawing.Size(26, 13);
+			this.lblRandomArrivalDelaySeconds.TabIndex = 3;
+			this.lblRandomArrivalDelaySeconds.Text = "Sec";
+			// 
+			// lblRandomArrivalDelayDesc
+			// 
+			this.lblRandomArrivalDelayDesc.Location = new System.Drawing.Point(17, 55);
+			this.lblRandomArrivalDelayDesc.Name = "lblRandomArrivalDelayDesc";
+			this.lblRandomArrivalDelayDesc.Size = new System.Drawing.Size(482, 52);
+			this.lblRandomArrivalDelayDesc.TabIndex = 2;
+			this.lblRandomArrivalDelayDesc.Text = resources.GetString("lblRandomArrivalDelayDesc.Text");
+			// 
+			// cboStopArrivingWhen
+			// 
+			this.cboStopArrivingWhen.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboStopArrivingWhen.FormattingEnabled = true;
+			this.cboStopArrivingWhen.Location = new System.Drawing.Point(121, 21);
+			this.cboStopArrivingWhen.Name = "cboStopArrivingWhen";
+			this.cboStopArrivingWhen.Size = new System.Drawing.Size(208, 21);
+			this.cboStopArrivingWhen.TabIndex = 1;
+			// 
+			// lblStopArrivingWhen
+			// 
+			this.lblStopArrivingWhen.AutoSize = true;
+			this.lblStopArrivingWhen.Location = new System.Drawing.Point(17, 24);
+			this.lblStopArrivingWhen.Name = "lblStopArrivingWhen";
+			this.lblStopArrivingWhen.Size = new System.Drawing.Size(98, 13);
+			this.lblStopArrivingWhen.TabIndex = 0;
+			this.lblStopArrivingWhen.Text = "Stop arriving when:";
+			// 
 			// tabUnk
 			// 
 			this.tabUnk.Controls.Add(this.grpUnkOther);
@@ -3962,6 +4072,14 @@ namespace Idmr.Yogeme
 			this.grpUnkOther.TabStop = false;
 			this.grpUnkOther.Text = "Options/Other";
 			this.grpUnkOther.Leave += new System.EventHandler(this.grpUnkOther_Leave);
+			// 
+			// label26
+			// 
+			this.label26.Location = new System.Drawing.Point(126, 33);
+			this.label26.Name = "label26";
+			this.label26.Size = new System.Drawing.Size(137, 23);
+			this.label26.TabIndex = 13;
+			this.label26.Text = "0x520 PreventNumbering";
 			// 
 			// label93
 			// 
@@ -4210,9 +4328,7 @@ namespace Idmr.Yogeme
 			// 
 			this.grpUnkAD.Controls.Add(this.numUnk5);
 			this.grpUnkAD.Controls.Add(this.label87);
-			this.grpUnkAD.Controls.Add(this.numUnk4);
 			this.grpUnkAD.Controls.Add(this.label86);
-			this.grpUnkAD.Controls.Add(this.numUnk3);
 			this.grpUnkAD.Controls.Add(this.label85);
 			this.grpUnkAD.Location = new System.Drawing.Point(8, 80);
 			this.grpUnkAD.Name = "grpUnkAD";
@@ -4243,56 +4359,30 @@ namespace Idmr.Yogeme
 			this.label87.Text = "0x98";
 			this.label87.TextAlign = System.Drawing.ContentAlignment.BottomRight;
 			// 
-			// numUnk4
-			// 
-			this.numUnk4.Location = new System.Drawing.Point(160, 24);
-			this.numUnk4.Maximum = new decimal(new int[] {
-            256,
-            0,
-            0,
-            0});
-			this.numUnk4.Name = "numUnk4";
-			this.numUnk4.Size = new System.Drawing.Size(48, 20);
-			this.numUnk4.TabIndex = 1;
-			// 
 			// label86
 			// 
-			this.label86.Location = new System.Drawing.Point(112, 24);
+			this.label86.Location = new System.Drawing.Point(112, 26);
 			this.label86.Name = "label86";
-			this.label86.Size = new System.Drawing.Size(40, 16);
+			this.label86.Size = new System.Drawing.Size(104, 16);
 			this.label86.TabIndex = 3;
-			this.label86.Text = "0x96";
-			this.label86.TextAlign = System.Drawing.ContentAlignment.BottomRight;
-			// 
-			// numUnk3
-			// 
-			this.numUnk3.Location = new System.Drawing.Point(64, 24);
-			this.numUnk3.Maximum = new decimal(new int[] {
-            256,
-            0,
-            0,
-            0});
-			this.numUnk3.Name = "numUnk3";
-			this.numUnk3.Size = new System.Drawing.Size(48, 20);
-			this.numUnk3.TabIndex = 1;
+			this.label86.Text = "0x96 RndArrivalSec";
 			// 
 			// label85
 			// 
-			this.label85.Location = new System.Drawing.Point(16, 24);
+			this.label85.Location = new System.Drawing.Point(8, 26);
 			this.label85.Name = "label85";
-			this.label85.Size = new System.Drawing.Size(40, 16);
+			this.label85.Size = new System.Drawing.Size(104, 16);
 			this.label85.TabIndex = 3;
-			this.label85.Text = "0x85";
-			this.label85.TextAlign = System.Drawing.ContentAlignment.BottomRight;
+			this.label85.Text = "0x85 RndArrivalMin";
 			// 
 			// grpUnkCraft
 			// 
+			this.grpUnkCraft.Controls.Add(this.label27);
 			this.grpUnkCraft.Controls.Add(this.numUnk1);
 			this.grpUnkCraft.Controls.Add(this.label83);
-			this.grpUnkCraft.Controls.Add(this.chkUnk2);
 			this.grpUnkCraft.Location = new System.Drawing.Point(8, 8);
 			this.grpUnkCraft.Name = "grpUnkCraft";
-			this.grpUnkCraft.Size = new System.Drawing.Size(184, 56);
+			this.grpUnkCraft.Size = new System.Drawing.Size(263, 56);
 			this.grpUnkCraft.TabIndex = 7;
 			this.grpUnkCraft.TabStop = false;
 			this.grpUnkCraft.Text = "Craft";
@@ -4318,15 +4408,6 @@ namespace Idmr.Yogeme
 			this.label83.TabIndex = 3;
 			this.label83.Text = "0x62";
 			this.label83.TextAlign = System.Drawing.ContentAlignment.BottomRight;
-			// 
-			// chkUnk2
-			// 
-			this.chkUnk2.Location = new System.Drawing.Point(120, 17);
-			this.chkUnk2.Name = "chkUnk2";
-			this.chkUnk2.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.chkUnk2.Size = new System.Drawing.Size(56, 32);
-			this.chkUnk2.TabIndex = 2;
-			this.chkUnk2.Text = "0x63";
 			// 
 			// grpUnkGoal
 			// 
@@ -6752,13 +6833,13 @@ namespace Idmr.Yogeme
 			this.dataWaypoints_Raw.AllowDelete = false;
 			this.dataWaypoints_Raw.AllowNew = false;
 			// 
-			// label26
+			// label27
 			// 
-			this.label26.Location = new System.Drawing.Point(126, 33);
-			this.label26.Name = "label26";
-			this.label26.Size = new System.Drawing.Size(137, 23);
-			this.label26.TabIndex = 13;
-			this.label26.Text = "0x520 PreventNumbering";
+			this.label27.Location = new System.Drawing.Point(117, 24);
+			this.label27.Name = "label27";
+			this.label27.Size = new System.Drawing.Size(131, 23);
+			this.label27.TabIndex = 4;
+			this.label27.Text = "0x63 StopArrivingWhen";
 			// 
 			// XvtForm
 			// 
@@ -6842,6 +6923,11 @@ namespace Idmr.Yogeme
 			this.groupBox21.ResumeLayout(false);
 			this.groupBox20.ResumeLayout(false);
 			this.groupBox19.ResumeLayout(false);
+			this.tabArrDep2.ResumeLayout(false);
+			this.grpMoreArrival.ResumeLayout(false);
+			this.grpMoreArrival.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numRandomArrivalDelayMinutes)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numRandomArrivalDelaySeconds)).EndInit();
 			this.tabUnk.ResumeLayout(false);
 			this.grpUnkOther.ResumeLayout(false);
 			this.grpUnkOrder.ResumeLayout(false);
@@ -6852,8 +6938,6 @@ namespace Idmr.Yogeme
 			((System.ComponentModel.ISupportInitialize)(this.numUnk9)).EndInit();
 			this.grpUnkAD.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.numUnk5)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numUnk4)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numUnk3)).EndInit();
 			this.grpUnkCraft.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.numUnk1)).EndInit();
 			this.grpUnkGoal.ResumeLayout(false);
@@ -6990,11 +7074,8 @@ namespace Idmr.Yogeme
 		CheckBox chkMissUnk3;
 		CheckBox chkPreventOutcome;
 		NumericUpDown numUnk1;
-		CheckBox chkUnk2;
 		Label label83;
 		Label label85;
-		NumericUpDown numUnk3;
-		NumericUpDown numUnk4;
 		Label label86;
 		NumericUpDown numUnk5;
 		Label label87;
@@ -7491,5 +7572,15 @@ namespace Idmr.Yogeme
         private TextBox txtIFF5;
         private TextBox txtIFF6;
 		private Label label26;
+		private TabPage tabArrDep2;
+		private Label lblRandomArrivalDelayMinutes;
+		private Label lblRandomArrivalDelaySeconds;
+		private Label lblRandomArrivalDelayDesc;
+		private ComboBox cboStopArrivingWhen;
+		private Label lblStopArrivingWhen;
+		private NumericUpDown numRandomArrivalDelayMinutes;
+		private NumericUpDown numRandomArrivalDelaySeconds;
+		private GroupBox grpMoreArrival;
+		private Label label27;
 	}
 }

--- a/XvtForm.Designer.cs
+++ b/XvtForm.Designer.cs
@@ -507,6 +507,8 @@ namespace Idmr.Yogeme
 			this.lblTeam9 = new System.Windows.Forms.Label();
 			this.lblTeam10 = new System.Windows.Forms.Label();
 			this.tabMission = new System.Windows.Forms.TabPage();
+			this.numRndSeed = new System.Windows.Forms.NumericUpDown();
+			this.label29 = new System.Windows.Forms.Label();
 			this.grpIFF = new System.Windows.Forms.GroupBox();
 			this.txtIFF6 = new System.Windows.Forms.TextBox();
 			this.txtIFF5 = new System.Windows.Forms.TextBox();
@@ -705,6 +707,7 @@ namespace Idmr.Yogeme
 			this.groupBox31.SuspendLayout();
 			this.groupBox30.SuspendLayout();
 			this.tabMission.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numRndSeed)).BeginInit();
 			this.grpIFF.SuspendLayout();
 			this.groupBox36.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numMissUnk1)).BeginInit();
@@ -5897,6 +5900,8 @@ namespace Idmr.Yogeme
 			// 
 			// tabMission
 			// 
+			this.tabMission.Controls.Add(this.numRndSeed);
+			this.tabMission.Controls.Add(this.label29);
 			this.tabMission.Controls.Add(this.grpIFF);
 			this.tabMission.Controls.Add(this.label150);
 			this.tabMission.Controls.Add(this.groupBox36);
@@ -5922,6 +5927,28 @@ namespace Idmr.Yogeme
 			this.tabMission.Size = new System.Drawing.Size(785, 510);
 			this.tabMission.TabIndex = 4;
 			this.tabMission.Text = "Mission";
+			// 
+			// numRndSeed
+			// 
+			this.numRndSeed.Location = new System.Drawing.Point(451, 451);
+			this.numRndSeed.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+			this.numRndSeed.Name = "numRndSeed";
+			this.numRndSeed.Size = new System.Drawing.Size(49, 20);
+			this.numRndSeed.TabIndex = 20;
+			this.numRndSeed.ValueChanged += new System.EventHandler(this.numRndSeed_ValueChanged);
+			// 
+			// label29
+			// 
+			this.label29.AutoSize = true;
+			this.label29.Location = new System.Drawing.Point(318, 453);
+			this.label29.Name = "label29";
+			this.label29.Size = new System.Drawing.Size(128, 13);
+			this.label29.TabIndex = 19;
+			this.label29.Text = "Asteroid randomizer seed:";
 			// 
 			// grpIFF
 			// 
@@ -6849,6 +6876,7 @@ namespace Idmr.Yogeme
 			this.groupBox30.ResumeLayout(false);
 			this.tabMission.ResumeLayout(false);
 			this.tabMission.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numRndSeed)).EndInit();
 			this.grpIFF.ResumeLayout(false);
 			this.grpIFF.PerformLayout();
 			this.groupBox36.ResumeLayout(false);
@@ -7448,5 +7476,7 @@ namespace Idmr.Yogeme
 		private ListBox lstGoalTeams;
 		private Label label28;
 		private Label label92;
+		private NumericUpDown numRndSeed;
+		private Label label29;
 	}
 }

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -1091,8 +1091,8 @@ namespace Idmr.Yogeme
 			ComboBox variableType;
 			ColorizedFGList.TryGetValue(variable, out variableType);
 			bool colorize = true;
-			if (variableType != null)        //If a VariableType selection control is attached, check that Flight Group is selected.
-				colorize = (variableType.SelectedIndex == 1);
+			if (variableType != null)        //If a VariableType selection control is attached, check that a Flight Group type is selected.
+				colorize = (variableType.SelectedIndex == 1 || variableType.SelectedIndex == 0xF);
 
 			if (e.Index == -1 || e.Index >= _mission.FlightGroups.Count) colorize = false;
 

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -1058,6 +1058,7 @@ namespace Idmr.Yogeme
 			}
 			cboMissType.SelectedIndex = (int)_mission.MissionType;
 			chkPreventOutcome.Checked = _mission.PreventMissionOutcome;
+			numRndSeed.Value = _mission.RndSeed;
 			numMissTimeMin.Value = _mission.TimeLimitMin;
 			numMissTimeSec.Value = _mission.TimeLimitSec;
 			txtMissDesc.Text = _mission.MissionDescription;
@@ -4090,7 +4091,10 @@ namespace Idmr.Yogeme
 		{
 			_mission.PreventMissionOutcome = Common.Update(this, _mission.PreventMissionOutcome, chkPreventOutcome.Checked);
 		}
-
+		private void numRndSeed_ValueChanged(object sender, EventArgs e)
+		{
+			_mission.RndSeed = Common.Update(this, _mission.RndSeed, Convert.ToByte(numRndSeed.Value));
+		}
 		void numMissTimeMin_Leave(object sender, EventArgs e)
 		{
 			_mission.TimeLimitMin = Common.Update(this, _mission.TimeLimitMin, Convert.ToByte(numMissTimeMin.Value));

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -127,6 +127,7 @@ namespace Idmr.Yogeme
 		MapForm _fMap;
 		BriefingForm _fBrief;
 		LstForm _fLST;
+		FlightGroupLibraryForm _fLibrary;
 		byte _activeMessageTrigger = 0;
 		byte _activeGlobalTrigger = 0;
 		byte _activeTeam = 0;
@@ -189,6 +190,7 @@ namespace Idmr.Yogeme
 			if (_fMap != null) _fMap.Close();
 			if (_fBrief != null) _fBrief.Close();
 			if (_fLST != null) _fLST.Close();
+			if (_fLibrary != null) _fLibrary.Close();
 		}
 		void comboVarRefresh(int index, ComboBox cbo)
 		{   //index is usually cboTrigType.SelectedIndex, cbo = cboTrigVar
@@ -1405,6 +1407,25 @@ namespace Idmr.Yogeme
 		{
 			string output = "(global goals not included):\r\n----------\r\n" + generateGoalSummary();
 			new GoalSummaryDialog(output).Show();
+		}
+		void menuLibrary_Click(object sender, EventArgs e)
+		{
+			if (_fLibrary != null)
+				_fLibrary.Close();
+			_fLibrary = new FlightGroupLibraryForm(Settings.Platform.XvT, _mission.FlightGroups, flightGroupLibraryCallback);
+		}
+		void flightGroupLibraryCallback(object sender, EventArgs e)
+		{
+			foreach (FlightGroup fg in (object[])sender)
+			{
+				if (fg == null || newFG() == false)
+					break;
+				_mission.FlightGroups[_activeFG] = fg;
+				updateFGList();
+				listRefresh();
+				_startingShips--;
+				craftStart(fg, true);
+			}
 		}
 		void menuHelpInfo_Click(object sender, EventArgs e)
 		{

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -638,7 +638,7 @@ namespace Idmr.Yogeme
 			#region FlightGroups
 			#region Craft
 			cboCraft.SelectedIndex = _mission.FlightGroups[0].CraftType; // already loaded in loadCraftData
-			cboIFF.Items.AddRange(Strings.IFF); cboIFF.SelectedIndex = _mission.FlightGroups[0].IFF;
+			cboIFF.SelectedIndex = _mission.FlightGroups[0].IFF; // already loaded in this function
 			cboTeam.Items.AddRange(_mission.Teams.GetList()); cboTeam.SelectedIndex = _mission.FlightGroups[0].Team;
 			cboAI.Items.AddRange(Strings.Rating); cboAI.SelectedIndex = _mission.FlightGroups[0].AI;
 			cboMarkings.Items.AddRange(Strings.Color); cboMarkings.SelectedIndex = _mission.FlightGroups[0].Markings;

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -690,6 +690,7 @@ namespace Idmr.Yogeme
 				optADAndOr[i].CheckedChanged += new EventHandler(optADAndOrArr_CheckedChanged);
 				optADAndOr[i].Tag = i;
 			}
+			cboStopArrivingWhen.Items.AddRange(Strings.StopArrivingWhen);
 			#endregion
 			#region Orders
 			cboOrders.Items.AddRange(Strings.Orders);
@@ -2419,6 +2420,9 @@ namespace Idmr.Yogeme
 			chkArrHuman.Checked = _mission.FlightGroups[_activeFG].ArriveOnlyIfHuman;
 			for (int i = 0; i < 6; i++) labelRefresh(_mission.FlightGroups[_activeFG].ArrDepTriggers[i], lblADTrig[i]);
 			lblADTrigArr_Click(lblADTrig[0], new EventArgs());  //[JB] Added sender.  Fixes massive slowdown from exception handling a null control.  Also fixed the remaining _Click() calls with the relevant senders.
+			Common.SafeSetCBO(cboStopArrivingWhen, _mission.FlightGroups[_activeFG].StopArrivingWhen, true);
+			numRandomArrivalDelayMinutes.Value = _mission.FlightGroups[_activeFG].RandomArrivalDelayMinutes;
+			numRandomArrivalDelaySeconds.Value = _mission.FlightGroups[_activeFG].RandomArrivalDelaySeconds;
 			#endregion
 			for (_activeFGGoal = 0; _activeFGGoal < 8; _activeFGGoal++) goalLabelRefresh();
 			lblGoalArr_Click(lblGoal[0], new EventArgs());
@@ -2446,9 +2450,6 @@ namespace Idmr.Yogeme
 			#endregion
 			#region Unknowns
 			numUnk1.Value = _mission.FlightGroups[_activeFG].Unknowns.Unknown1;
-			chkUnk2.Checked = _mission.FlightGroups[_activeFG].Unknowns.Unknown2;
-			numUnk3.Value = _mission.FlightGroups[_activeFG].Unknowns.Unknown3;
-			numUnk4.Value = _mission.FlightGroups[_activeFG].Unknowns.Unknown4;
 			numUnk5.Value = _mission.FlightGroups[_activeFG].Unknowns.Unknown5;
 			numUnkOrder.Value = 1;
 			numUnkOrder_ValueChanged(0, new EventArgs()); //[JB] Force refresh of associated checkboxes
@@ -2832,6 +2833,13 @@ namespace Idmr.Yogeme
 		{
 			cboDepMSAlt.Enabled = optDepMSAlt.Checked;
 			if (!_loading) _mission.FlightGroups[_activeFG].DepartureMethod2 = Common.Update(this, _mission.FlightGroups[_activeFG].DepartureMethod2, optDepMSAlt.Checked);
+		}
+
+		private void grpMoreArrival_Leave(object sender, EventArgs e)
+		{
+			_mission.FlightGroups[_activeFG].StopArrivingWhen = Common.Update(this, _mission.FlightGroups[_activeFG].StopArrivingWhen, Convert.ToByte(cboStopArrivingWhen.SelectedIndex));
+			_mission.FlightGroups[_activeFG].RandomArrivalDelayMinutes = Common.Update(this, _mission.FlightGroups[_activeFG].RandomArrivalDelayMinutes, Convert.ToByte(numRandomArrivalDelayMinutes.Value));
+			_mission.FlightGroups[_activeFG].RandomArrivalDelaySeconds = Common.Update(this, _mission.FlightGroups[_activeFG].RandomArrivalDelaySeconds, Convert.ToByte(numRandomArrivalDelaySeconds.Value));
 		}
 		#endregion
 		#region Orders
@@ -3598,14 +3606,11 @@ namespace Idmr.Yogeme
 		#region Unknowns
 		void grpUnkAD_Leave(object sender, EventArgs e)
 		{
-			_mission.FlightGroups[_activeFG].Unknowns.Unknown3 = Common.Update(this, _mission.FlightGroups[_activeFG].Unknowns.Unknown3, Convert.ToByte(numUnk3.Value));
-			_mission.FlightGroups[_activeFG].Unknowns.Unknown4 = Common.Update(this, _mission.FlightGroups[_activeFG].Unknowns.Unknown4, Convert.ToByte(numUnk4.Value));
 			_mission.FlightGroups[_activeFG].Unknowns.Unknown5 = Common.Update(this, _mission.FlightGroups[_activeFG].Unknowns.Unknown5, Convert.ToByte(numUnk5.Value));
 		}
 		void grpUnkCraft_Leave(object sender, EventArgs e)
 		{
 			_mission.FlightGroups[_activeFG].Unknowns.Unknown1 = Common.Update(this, _mission.FlightGroups[_activeFG].Unknowns.Unknown1, Convert.ToByte(numUnk1.Value));
-			_mission.FlightGroups[_activeFG].Unknowns.Unknown2 = Common.Update(this, _mission.FlightGroups[_activeFG].Unknowns.Unknown2, chkUnk2.Checked);
 		}
 		void grpUnkGoal_Leave(object sender, EventArgs e)
 		{

--- a/XvtForm.resx
+++ b/XvtForm.resx
@@ -356,6 +356,12 @@ If disabled, a flat delay of half this amount is added.</value>
   <metadata name="chkWPBrief8.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="lblRandomArrivalDelayDesc.Text" xml:space="preserve">
+    <value>Randomized arrival delay. Stacks more delay time with the normal arrival trigger delay,
+based on whether the mission Randomize feature is enabled in-game.
+If enabled, a randomized delay from 1 second up to the amount here is added.
+If disabled, a flat delay of half this amount is added.</value>
+  </data>
   <metadata name="menuXvT.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/XvtForm.resx
+++ b/XvtForm.resx
@@ -183,6 +183,12 @@
   <metadata name="chkWPBrief8.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="lblRandomArrivalDelayDesc.Text" xml:space="preserve">
+    <value>Randomized arrival delay. Stacks more delay time with the normal arrival trigger delay,
+based on whether the mission Randomize feature is enabled in-game.
+If enabled, a randomized delay from 1 second up to the amount here is added.
+If disabled, a flat delay of half this amount is added.</value>
+  </data>
   <metadata name="imgToolbar.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>117, 17</value>
   </metadata>

--- a/XwaForm.Designer.cs
+++ b/XwaForm.Designer.cs
@@ -59,6 +59,7 @@ namespace Idmr.Yogeme
 			this.menuGoalSummary = new System.Windows.Forms.MenuItem();
 			this.menuHyperbuoy = new System.Windows.Forms.MenuItem();
 			this.menuSuperBackdrops = new System.Windows.Forms.MenuItem();
+			this.menuHooks = new System.Windows.Forms.MenuItem();
 			this.menuText = new System.Windows.Forms.MenuItem();
 			this.menuHelp = new System.Windows.Forms.MenuItem();
 			this.menuHelpInfo = new System.Windows.Forms.MenuItem();
@@ -783,7 +784,7 @@ namespace Idmr.Yogeme
 			this.txtNotes = new System.Windows.Forms.TextBox();
 			this.dataOrders = new System.Data.DataView();
 			this.dataOrders_Raw = new System.Data.DataView();
-			this.menuHooks = new System.Windows.Forms.MenuItem();
+			this.menuLibrary = new System.Windows.Forms.MenuItem();
 			((System.ComponentModel.ISupportInitialize)(this.dataWaypoints)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.dataWaypoints_Raw)).BeginInit();
 			this.tabMain.SuspendLayout();
@@ -1183,6 +1184,7 @@ namespace Idmr.Yogeme
             this.menuLST,
             this.menuOptions,
             this.menuGoalSummary,
+            this.menuLibrary,
             this.menuHyperbuoy,
             this.menuSuperBackdrops,
             this.menuHooks});
@@ -1226,15 +1228,22 @@ namespace Idmr.Yogeme
 			// 
 			// menuHyperbuoy
 			// 
-			this.menuHyperbuoy.Index = 6;
+			this.menuHyperbuoy.Index = 7;
 			this.menuHyperbuoy.Text = "&Hyperbouy Wizard";
 			this.menuHyperbuoy.Click += new System.EventHandler(this.menuHyperbuoy_Click);
 			// 
 			// menuSuperBackdrops
 			// 
-			this.menuSuperBackdrops.Index = 7;
+			this.menuSuperBackdrops.Index = 8;
 			this.menuSuperBackdrops.Text = "Apply &Super Backdrops";
 			this.menuSuperBackdrops.Click += new System.EventHandler(this.menuSuperBackdrops_Click);
+			// 
+			// menuHooks
+			// 
+			this.menuHooks.Enabled = false;
+			this.menuHooks.Index = 9;
+			this.menuHooks.Text = "Hoo&k Assignment";
+			this.menuHooks.Click += new System.EventHandler(this.menuHooks_Click);
 			// 
 			// menuText
 			// 
@@ -9232,12 +9241,11 @@ namespace Idmr.Yogeme
 			this.dataOrders_Raw.AllowDelete = false;
 			this.dataOrders_Raw.AllowNew = false;
 			// 
-			// menuHooks
+			// menuLibrary
 			// 
-			this.menuHooks.Enabled = false;
-			this.menuHooks.Index = 8;
-			this.menuHooks.Text = "Hoo&k Assignment";
-			this.menuHooks.Click += new System.EventHandler(this.menuHooks_Click);
+			this.menuLibrary.Index = 6;
+			this.menuLibrary.Text = "FG Librar&y";
+			this.menuLibrary.Click += new System.EventHandler(this.menuLibrary_Click);
 			// 
 			// XwaForm
 			// 
@@ -10238,5 +10246,6 @@ namespace Idmr.Yogeme
 		private NumericUpDown numUnk42;
 		private Label label152;
 		private MenuItem menuHooks;
+		private MenuItem menuLibrary;
 	}
 }

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -1295,7 +1295,7 @@ namespace Idmr.Yogeme
 				colorize = (variableType.SelectedIndex == 1 || variableType.SelectedIndex == 0xF);
 
 			int paramOffset = 0;
-			if (variableType == null && variable.Items.Count == _mission.FlightGroups.Count + 5 && _mission.FlightGroups.Count >= 1)  //Detect if it's a parameter dropdown, which have 5 entries (for region #) before the FG list starts.  Parameter dropdowns are not attached to VariableType dropdowns, either.
+			if (variableType == null && variable.Items.Count >= _mission.FlightGroups.Count + 5 && _mission.FlightGroups.Count >= 1)  //Detect if it's a parameter dropdown, which have 5 entries (for region #) before the FG list starts.  Parameter dropdowns are not attached to VariableType dropdowns, either.
 			{
 				if (variable.Items[5].ToString() == _mission.FlightGroups[0].ToString(false))  //Check to make sure it really does contain FGs by checking the first one.
 					paramOffset = 5;
@@ -1305,10 +1305,9 @@ namespace Idmr.Yogeme
 
 			if (e.Index == -1 || e.Index - paramOffset >= _mission.FlightGroups.Count) colorize = false;
 
-			if (variable.BackColor == Color.Black || variable.BackColor == SystemColors.Window)
-				variable.BackColor = (colorize ? Color.Black : SystemColors.Window);
-
 			e.DrawBackground();
+			// Setting the control BackColor will interrupt the drawing, so draw each item manually.
+			if (colorize && !e.State.HasFlag(DrawItemState.Selected)) e.Graphics.FillRectangle(Brushes.Black, e.Bounds);
 			Brush brText = SystemBrushes.ControlText;
 			if (colorize) brText = getFlightGroupDrawColor(e.Index - paramOffset);
 			if (brText == SystemBrushes.ControlText && variable.BackColor == Color.Black) brText = Brushes.LightGray;
@@ -3152,10 +3151,7 @@ namespace Idmr.Yogeme
 			cboADTrigType.SelectedIndex = _mission.FlightGroups[_activeFG].ArrDepTriggers[_activeArrDepTrigger].VariableType;
 			cboADTrigAmount.SelectedIndex = _mission.FlightGroups[_activeFG].ArrDepTriggers[_activeArrDepTrigger].Amount;
 			//[JB] Fixes exceptions for backdrop FGs in B4M2B.TIE, B4M3FB.TIE, B4M4B.TIE which use have Parameter1 values around 78 to 80
-			int v = _mission.FlightGroups[_activeFG].ArrDepTriggers[_activeArrDepTrigger].Parameter1;
-			if (v >= cboADPara.Items.Count)
-				v = cboADPara.Items.Count - 1;
-			cboADPara.SelectedIndex = v; //_mission.FlightGroups[_activeFG].ArrDepTriggers[_activeArrDepTrigger].Parameter1;
+			Common.SafeSetCBO(cboADPara, _mission.FlightGroups[_activeFG].ArrDepTriggers[_activeArrDepTrigger].Parameter1, true);
 			numADPara.Value = _mission.FlightGroups[_activeFG].ArrDepTriggers[_activeArrDepTrigger].Parameter2;
 			_loading = btemp;
 		}
@@ -4131,7 +4127,7 @@ namespace Idmr.Yogeme
 			cboSkipType.SelectedIndex = -1;
 			cboSkipType.SelectedIndex = trigger.VariableType;
 			cboSkipAmount.SelectedIndex = trigger.Amount;
-			cboSkipPara.SelectedIndex = trigger.Parameter1;
+			Common.SafeSetCBO(cboSkipPara, trigger.Parameter1, true);
 			numSkipPara.Value = trigger.Parameter2;
 			_loading = btemp;
 		}

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -258,8 +258,13 @@ namespace Idmr.Yogeme
 				case 7: // Craft when
 					cbo.Items.AddRange(Strings.CraftWhen);
 					break;
-				//case 8: Global Group
-				//since it's just numbers, same as default, left out for specifics
+				case 8:  //Global Group
+				case 20: //All Global Groups except
+					temp = new string[256];
+					for(int i = 0; i < 256; i++)
+						temp[i] = ((i < 16 && _mission.GlobalGroups[i] != "") ? i.ToString() + ": " + _mission.GlobalGroups[i] : i.ToString());
+					cbo.Items.AddRange(temp);
+					break;
 				case 9: // Rating
 					cbo.Items.AddRange(Strings.Rating);
 					break;
@@ -295,7 +300,7 @@ namespace Idmr.Yogeme
 				case 19: // All IFFs except
 					cbo.Items.AddRange(getIffStrings());
 					break;
-				//case 20: // All Global Groups except
+				//case 20: // All Global Groups except (handled above with Global Group)
 				case 21: // All Teams except
 					temp = _mission.Teams.GetList();
 					for (int i = 0; i < temp.Length; i++)
@@ -763,6 +768,11 @@ namespace Idmr.Yogeme
 			{
 				int team = Common.ParseIntAfter(text, "TM:");
 				text = text.Replace("TM:" + team, ((team >= 0 && team < 10 && _mission.Teams[team].Name != "") ? _mission.Teams[team].Name : "Team " + (team + 1).ToString()));
+			}
+			while (text.Contains("GG:"))
+			{
+				int gg = Common.ParseIntAfter(text, "GG:");
+				text = text.Replace("GG:" + gg, ((gg >= 0 && gg < 16 && _mission.GlobalGroups[gg] != "") ? "GG " + gg + ": " + _mission.GlobalGroups[gg] : "Global Group " + gg));
 			}
 			return text;
 		}
@@ -5024,7 +5034,7 @@ namespace Idmr.Yogeme
 		{
 			for (int i = 0; i < 16; i++)
 				if (_mission.GlobalGroups[i] != "") lblGG[i].Text = _mission.GlobalGroups[i];
-				else lblGG[i].Text = "Global Group " + (i + 1).ToString();
+				else lblGG[i].Text = "Global Group " + i.ToString();
 		}
 
 		void numGlobCargo_ValueChanged(object sender, EventArgs e)
@@ -5107,6 +5117,7 @@ namespace Idmr.Yogeme
 			for (i = 0; i < 16; i++) if (lblGG[i].ForeColor == getHighlightColor()) break;
 			_mission.GlobalGroups[i] = Common.Update(this, _mission.GlobalGroups[i], txtGlobGroup.Text);
 			ggRefresh();
+			updateFGList(); //Force refresh of any trigger labels that might contain the GG text.
 		}
 		void txtNotes_Leave(object sender, EventArgs e)
 		{

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -3996,6 +3996,7 @@ namespace Idmr.Yogeme
 		}
 		void refreshSkipIndicators()  //[JB] Maintain order indicators when a Skip Trigger is modified.
 		{
+			byte restore = _activeOrder;
 			//Scan through all of the orders in each region.  Determine if the Skip Trigger is potentially used.  If so update the dropdown list with an indicator, and also force a refresh on the corresponding item in the Orders tab.
 			for (int o = 0; o < 4; o++)
 			{
@@ -4029,6 +4030,7 @@ namespace Idmr.Yogeme
 					}
 				}
 			}
+			lblOrderArr_Click(lblOrder[restore], new EventArgs());  //Refreshing any of the labels will have changed the order selection, so restore it.
 		}
 
 		void chkOptArr_CheckedChanged(object sender, EventArgs e)

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -1291,8 +1291,8 @@ namespace Idmr.Yogeme
 			ComboBox variableType;
 			colorizedFGList.TryGetValue(variable, out variableType);
 			bool colorize = true;
-			if (variableType != null)        //If a VariableType selection control is attached, check that Flight Group is selected.
-				colorize = (variableType.SelectedIndex == 1);
+			if (variableType != null)        //If a VariableType selection control is attached, check that a Flight Group type is selected.
+				colorize = (variableType.SelectedIndex == 1 || variableType.SelectedIndex == 0xF);
 
 			int paramOffset = 0;
 			if (variableType == null && variable.Items.Count == _mission.FlightGroups.Count + 5 && _mission.FlightGroups.Count >= 1)  //Detect if it's a parameter dropdown, which have 5 entries (for region #) before the FG list starts.  Parameter dropdowns are not attached to VariableType dropdowns, either.

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -139,6 +139,7 @@ namespace Idmr.Yogeme
 		MapForm _fMap;
 		BriefingForm _fBrief;
 		LstForm _fLST;
+		FlightGroupLibraryForm _fLibrary;
 		Mission _mission;
 		bool _applicationExit;
 		int _activeFG = 0;
@@ -224,6 +225,8 @@ namespace Idmr.Yogeme
 			try { _fBrief.Close(); }
 			catch { /* do nothing */ }
 			try { _fLST.Close(); }
+			catch { /* do nothing */ }
+			try { _fLibrary.Close(); }
 			catch { /* do nothing */ }
 		}
 		void comboVarRefresh(int index, ComboBox cbo)
@@ -1629,6 +1632,26 @@ namespace Idmr.Yogeme
 		{
 			string output = "(global goals not included):\r\n----------\r\n" + generateGoalSummary();
 			new GoalSummaryDialog(output).Show();
+		}
+		void menuLibrary_Click(object sender, EventArgs e)
+		{
+			if (_fLibrary != null)
+				_fLibrary.Close();
+			_fLibrary = new FlightGroupLibraryForm(Settings.Platform.XWA, _mission.FlightGroups, flightGroupLibraryCallback);
+		}
+		void flightGroupLibraryCallback(object sender, EventArgs e)
+		{
+			foreach (FlightGroup fg in (object[])sender)
+			{
+				if (fg == null)
+					break;
+				newFG();
+				_mission.FlightGroups[_activeFG] = fg;
+				updateFGList();
+				listRefresh();
+				_startingShips--;
+				craftStart(fg, true);
+			}
 		}
 		void menuHelpInfo_Click(object sender, EventArgs e)
 		{

--- a/XwaHookDialog.Designer.cs
+++ b/XwaHookDialog.Designer.cs
@@ -123,6 +123,17 @@
 			this.numCameraX = new System.Windows.Forms.NumericUpDown();
 			this.cboCamera = new System.Windows.Forms.ComboBox();
 			this.grpHangarObjects = new System.Windows.Forms.GroupBox();
+			this.numPlayerAnimationElevation = new System.Windows.Forms.NumericUpDown();
+			this.label30 = new System.Windows.Forms.Label();
+			this.label29 = new System.Windows.Forms.Label();
+			this.numHangarRoofCranePositionZ = new System.Windows.Forms.NumericUpDown();
+			this.label28 = new System.Windows.Forms.Label();
+			this.numHangarRoofCranePositionY = new System.Windows.Forms.NumericUpDown();
+			this.label27 = new System.Windows.Forms.Label();
+			this.numShuDistance = new System.Windows.Forms.NumericUpDown();
+			this.cboShuAnimation = new System.Windows.Forms.ComboBox();
+			this.label26 = new System.Windows.Forms.Label();
+			this.label3 = new System.Windows.Forms.Label();
 			this.label2 = new System.Windows.Forms.Label();
 			this.cboShuttleMarks = new System.Windows.Forms.ComboBox();
 			this.chkFloor = new System.Windows.Forms.CheckBox();
@@ -134,10 +145,6 @@
 			this.cmdRemoveHangar = new System.Windows.Forms.Button();
 			this.lstHangarObjects = new System.Windows.Forms.ListBox();
 			this.chkHangars = new System.Windows.Forms.CheckBox();
-			this.label3 = new System.Windows.Forms.Label();
-			this.cboShuAnimation = new System.Windows.Forms.ComboBox();
-			this.label26 = new System.Windows.Forms.Label();
-			this.numShuDistance = new System.Windows.Forms.NumericUpDown();
 			this.grpBackdrops.SuspendLayout();
 			this.grpMission.SuspendLayout();
 			this.grpSounds.SuspendLayout();
@@ -164,13 +171,16 @@
 			((System.ComponentModel.ISupportInitialize)(this.numCameraY)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numCameraX)).BeginInit();
 			this.grpHangarObjects.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numPlayerAnimationElevation)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numHangarRoofCranePositionZ)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numHangarRoofCranePositionY)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numShuDistance)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// cmdOK
 			// 
 			this.cmdOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.cmdOK.Location = new System.Drawing.Point(602, 447);
+			this.cmdOK.Location = new System.Drawing.Point(602, 467);
 			this.cmdOK.Name = "cmdOK";
 			this.cmdOK.Size = new System.Drawing.Size(75, 23);
 			this.cmdOK.TabIndex = 0;
@@ -181,7 +191,7 @@
 			// cmdCancel
 			// 
 			this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cmdCancel.Location = new System.Drawing.Point(698, 447);
+			this.cmdCancel.Location = new System.Drawing.Point(698, 467);
 			this.cmdCancel.Name = "cmdCancel";
 			this.cmdCancel.Size = new System.Drawing.Size(75, 23);
 			this.cmdCancel.TabIndex = 0;
@@ -509,7 +519,7 @@
 			this.grpHangars.Controls.Add(this.chkHangars);
 			this.grpHangars.Location = new System.Drawing.Point(353, 12);
 			this.grpHangars.Name = "grpHangars";
-			this.grpHangars.Size = new System.Drawing.Size(655, 403);
+			this.grpHangars.Size = new System.Drawing.Size(655, 429);
 			this.grpHangars.TabIndex = 6;
 			this.grpHangars.TabStop = false;
 			this.grpHangars.Text = "Hangars";
@@ -1041,7 +1051,7 @@
 			this.grpFamilyCamera.Controls.Add(this.numFamilyCameraX);
 			this.grpFamilyCamera.Controls.Add(this.cboFamilyCamera);
 			this.grpFamilyCamera.Enabled = false;
-			this.grpFamilyCamera.Location = new System.Drawing.Point(6, 288);
+			this.grpFamilyCamera.Location = new System.Drawing.Point(6, 339);
 			this.grpFamilyCamera.Name = "grpFamilyCamera";
 			this.grpFamilyCamera.Size = new System.Drawing.Size(318, 82);
 			this.grpFamilyCamera.TabIndex = 5;
@@ -1168,7 +1178,7 @@
 			this.grpCamera.Controls.Add(this.numCameraX);
 			this.grpCamera.Controls.Add(this.cboCamera);
 			this.grpCamera.Enabled = false;
-			this.grpCamera.Location = new System.Drawing.Point(6, 200);
+			this.grpCamera.Location = new System.Drawing.Point(6, 250);
 			this.grpCamera.Name = "grpCamera";
 			this.grpCamera.Size = new System.Drawing.Size(318, 82);
 			this.grpCamera.TabIndex = 4;
@@ -1284,6 +1294,13 @@
 			// 
 			// grpHangarObjects
 			// 
+			this.grpHangarObjects.Controls.Add(this.numPlayerAnimationElevation);
+			this.grpHangarObjects.Controls.Add(this.label30);
+			this.grpHangarObjects.Controls.Add(this.label29);
+			this.grpHangarObjects.Controls.Add(this.numHangarRoofCranePositionZ);
+			this.grpHangarObjects.Controls.Add(this.label28);
+			this.grpHangarObjects.Controls.Add(this.numHangarRoofCranePositionY);
+			this.grpHangarObjects.Controls.Add(this.label27);
 			this.grpHangarObjects.Controls.Add(this.numShuDistance);
 			this.grpHangarObjects.Controls.Add(this.cboShuAnimation);
 			this.grpHangarObjects.Controls.Add(this.label26);
@@ -1301,10 +1318,145 @@
 			this.grpHangarObjects.Enabled = false;
 			this.grpHangarObjects.Location = new System.Drawing.Point(6, 42);
 			this.grpHangarObjects.Name = "grpHangarObjects";
-			this.grpHangarObjects.Size = new System.Drawing.Size(318, 152);
+			this.grpHangarObjects.Size = new System.Drawing.Size(318, 202);
 			this.grpHangarObjects.TabIndex = 2;
 			this.grpHangarObjects.TabStop = false;
 			this.grpHangarObjects.Text = "Objects";
+			// 
+			// numPlayerAnimationElevation
+			// 
+			this.numPlayerAnimationElevation.Location = new System.Drawing.Point(169, 170);
+			this.numPlayerAnimationElevation.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+			this.numPlayerAnimationElevation.Minimum = new decimal(new int[] {
+            65536,
+            0,
+            0,
+            -2147483648});
+			this.numPlayerAnimationElevation.Name = "numPlayerAnimationElevation";
+			this.numPlayerAnimationElevation.Size = new System.Drawing.Size(60, 20);
+			this.numPlayerAnimationElevation.TabIndex = 21;
+			// 
+			// label30
+			// 
+			this.label30.AutoSize = true;
+			this.label30.Location = new System.Drawing.Point(54, 172);
+			this.label30.Name = "label30";
+			this.label30.Size = new System.Drawing.Size(112, 13);
+			this.label30.TabIndex = 20;
+			this.label30.Text = "Player Anim Elevation:";
+			// 
+			// label29
+			// 
+			this.label29.AutoSize = true;
+			this.label29.Location = new System.Drawing.Point(81, 146);
+			this.label29.Name = "label29";
+			this.label29.Size = new System.Drawing.Size(14, 13);
+			this.label29.TabIndex = 19;
+			this.label29.Text = "Y";
+			// 
+			// numHangarRoofCranePositionZ
+			// 
+			this.numHangarRoofCranePositionZ.Location = new System.Drawing.Point(192, 144);
+			this.numHangarRoofCranePositionZ.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+			this.numHangarRoofCranePositionZ.Minimum = new decimal(new int[] {
+            65536,
+            0,
+            0,
+            -2147483648});
+			this.numHangarRoofCranePositionZ.Name = "numHangarRoofCranePositionZ";
+			this.numHangarRoofCranePositionZ.Size = new System.Drawing.Size(60, 20);
+			this.numHangarRoofCranePositionZ.TabIndex = 18;
+			// 
+			// label28
+			// 
+			this.label28.AutoSize = true;
+			this.label28.Location = new System.Drawing.Point(172, 146);
+			this.label28.Name = "label28";
+			this.label28.Size = new System.Drawing.Size(14, 13);
+			this.label28.TabIndex = 17;
+			this.label28.Text = "Z";
+			// 
+			// numHangarRoofCranePositionY
+			// 
+			this.numHangarRoofCranePositionY.Location = new System.Drawing.Point(101, 144);
+			this.numHangarRoofCranePositionY.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+			this.numHangarRoofCranePositionY.Minimum = new decimal(new int[] {
+            65536,
+            0,
+            0,
+            -2147483648});
+			this.numHangarRoofCranePositionY.Name = "numHangarRoofCranePositionY";
+			this.numHangarRoofCranePositionY.Size = new System.Drawing.Size(60, 20);
+			this.numHangarRoofCranePositionY.TabIndex = 16;
+			// 
+			// label27
+			// 
+			this.label27.AutoSize = true;
+			this.label27.Location = new System.Drawing.Point(9, 146);
+			this.label27.Name = "label27";
+			this.label27.Size = new System.Drawing.Size(64, 13);
+			this.label27.TabIndex = 15;
+			this.label27.Text = "Roof Crane:";
+			// 
+			// numShuDistance
+			// 
+			this.numShuDistance.Location = new System.Drawing.Point(252, 119);
+			this.numShuDistance.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+			this.numShuDistance.Minimum = new decimal(new int[] {
+            65536,
+            0,
+            0,
+            -2147483648});
+			this.numShuDistance.Name = "numShuDistance";
+			this.numShuDistance.Size = new System.Drawing.Size(60, 20);
+			this.numShuDistance.TabIndex = 14;
+			// 
+			// cboShuAnimation
+			// 
+			this.cboShuAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboShuAnimation.FormattingEnabled = true;
+			this.cboShuAnimation.Items.AddRange(new object[] {
+            "Right",
+            "Top",
+            "Bottom"});
+			this.cboShuAnimation.Location = new System.Drawing.Point(101, 118);
+			this.cboShuAnimation.Name = "cboShuAnimation";
+			this.cboShuAnimation.Size = new System.Drawing.Size(62, 21);
+			this.cboShuAnimation.TabIndex = 13;
+			// 
+			// label26
+			// 
+			this.label26.AutoSize = true;
+			this.label26.Location = new System.Drawing.Point(170, 121);
+			this.label26.Name = "label26";
+			this.label26.Size = new System.Drawing.Size(77, 13);
+			this.label26.TabIndex = 12;
+			this.label26.Text = "SHU Anim Dist";
+			// 
+			// label3
+			// 
+			this.label3.AutoSize = true;
+			this.label3.Location = new System.Drawing.Point(9, 121);
+			this.label3.Name = "label3";
+			this.label3.Size = new System.Drawing.Size(79, 13);
+			this.label3.TabIndex = 12;
+			this.label3.Text = "SHU Animation";
 			// 
 			// label2
 			// 
@@ -1413,54 +1565,6 @@
 			this.chkHangars.UseVisualStyleBackColor = true;
 			this.chkHangars.CheckedChanged += new System.EventHandler(this.chkHangars_CheckedChanged);
 			// 
-			// label3
-			// 
-			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(9, 121);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(79, 13);
-			this.label3.TabIndex = 12;
-			this.label3.Text = "SHU Animation";
-			// 
-			// cboShuAnimation
-			// 
-			this.cboShuAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboShuAnimation.FormattingEnabled = true;
-			this.cboShuAnimation.Items.AddRange(new object[] {
-            "Right",
-            "Top",
-            "Bottom"});
-			this.cboShuAnimation.Location = new System.Drawing.Point(101, 118);
-			this.cboShuAnimation.Name = "cboShuAnimation";
-			this.cboShuAnimation.Size = new System.Drawing.Size(62, 21);
-			this.cboShuAnimation.TabIndex = 13;
-			// 
-			// label26
-			// 
-			this.label26.AutoSize = true;
-			this.label26.Location = new System.Drawing.Point(170, 121);
-			this.label26.Name = "label26";
-			this.label26.Size = new System.Drawing.Size(77, 13);
-			this.label26.TabIndex = 12;
-			this.label26.Text = "SHU Anim Dist";
-			// 
-			// numShuDistance
-			// 
-			this.numShuDistance.Location = new System.Drawing.Point(252, 119);
-			this.numShuDistance.Maximum = new decimal(new int[] {
-            65535,
-            0,
-            0,
-            0});
-			this.numShuDistance.Minimum = new decimal(new int[] {
-            65536,
-            0,
-            0,
-            -2147483648});
-			this.numShuDistance.Name = "numShuDistance";
-			this.numShuDistance.Size = new System.Drawing.Size(60, 20);
-			this.numShuDistance.TabIndex = 14;
-			// 
 			// XwaHookDialog
 			// 
 			this.AcceptButton = this.cmdOK;
@@ -1516,6 +1620,9 @@
 			((System.ComponentModel.ISupportInitialize)(this.numCameraX)).EndInit();
 			this.grpHangarObjects.ResumeLayout(false);
 			this.grpHangarObjects.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numPlayerAnimationElevation)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numHangarRoofCranePositionZ)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numHangarRoofCranePositionY)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numShuDistance)).EndInit();
 			this.ResumeLayout(false);
 
@@ -1632,5 +1739,12 @@
 		private System.Windows.Forms.Label label3;
 		private System.Windows.Forms.NumericUpDown numShuDistance;
 		private System.Windows.Forms.Label label26;
+		private System.Windows.Forms.NumericUpDown numPlayerAnimationElevation;
+		private System.Windows.Forms.Label label30;
+		private System.Windows.Forms.Label label29;
+		private System.Windows.Forms.NumericUpDown numHangarRoofCranePositionZ;
+		private System.Windows.Forms.Label label28;
+		private System.Windows.Forms.NumericUpDown numHangarRoofCranePositionY;
+		private System.Windows.Forms.Label label27;
 	}
 }

--- a/XwaHookDialog.cs
+++ b/XwaHookDialog.cs
@@ -91,6 +91,8 @@ namespace Idmr.Yogeme
 				cboFamMapIndex.Items.Add(i);
 			}
 			cboShuttleModel.SelectedIndex = 50;
+			numHangarRoofCranePositionY.Value = 786;
+			numHangarRoofCranePositionZ.Value = -282;
 			cboMapIndex.SelectedIndex = 0;
 			cboFamMapIndex.SelectedIndex = 0;
 			for (int i = 4; i >= 0; i--)
@@ -205,6 +207,9 @@ namespace Idmr.Yogeme
 							try { cboShuAnimation.SelectedIndex = (int)Enum.Parse(typeof(ShuttleAnimation), parts[1], true); }
 							catch { MessageBox.Show("Error reading ShuttleAnimation, using default.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error); }
 						else if (parts[0] == "shuttleanimiationstraightline") numShuDistance.Value = int.Parse(parts[1]);
+						else if (parts[0] == "hangarroofcranepositiony") numHangarRoofCranePositionY.Value = int.Parse(parts[1]);
+						else if (parts[0] == "hangarroofcranepositionz") numHangarRoofCranePositionZ.Value = int.Parse(parts[1]);
+						else if (parts[0] == "playeranimationelevation") numPlayerAnimationElevation.Value = int.Parse(parts[1]);
 						else lstHangarObjects.Items.Add(line);
 					}
 				}
@@ -341,6 +346,9 @@ namespace Idmr.Yogeme
 								try { cboShuAnimation.SelectedIndex = (int)Enum.Parse(typeof(ShuttleAnimation), parts[1], true); }
 								catch { MessageBox.Show("Error reading ShuttleAnimation, using default.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error); }
 							else if (parts[0] == "shuttleanimationstraightline") numShuDistance.Value = int.Parse(parts[1]);
+							else if (parts[0] == "hangarroofcranepositiony") numHangarRoofCranePositionY.Value = int.Parse(parts[1]);
+							else if (parts[0] == "hangarroofcranepositionz") numHangarRoofCranePositionZ.Value = int.Parse(parts[1]);
+							else if (parts[0] == "playeranimationelevation") numPlayerAnimationElevation.Value = int.Parse(parts[1]);
 							else lstHangarObjects.Items.Add(line);
 						}
 					}
@@ -876,6 +884,9 @@ namespace Idmr.Yogeme
 						if (chkFloor.Checked) sw.WriteLine("IsHangarFloorInverted = 1");
 						if (cboShuAnimation.SelectedIndex != 0) sw.WriteLine("ShuttleAnimation = " + cboShuAnimation.Text);
 						if (numShuDistance.Value != 0) sw.WriteLine("ShuttleAnimationStraightLine = " + (int)numShuDistance.Value);
+						if (numHangarRoofCranePositionY.Value != 786) sw.WriteLine("HangarRoofCranePositionY = " + (int)numHangarRoofCranePositionY.Value);
+						if (numHangarRoofCranePositionZ.Value != -282) sw.WriteLine("HangarRoofCranePositionZ = " + (int)numHangarRoofCranePositionZ.Value);
+						if (numPlayerAnimationElevation.Value != 0) sw.WriteLine("PlayerAnimationElevation = " + (int)numPlayerAnimationElevation.Value);
 						for (int i = 0; i < lstHangarObjects.Items.Count; i++) sw.WriteLine(lstHangarObjects.Items[i]);
 						sw.WriteLine("");
 					}

--- a/XwaHookDialog.cs
+++ b/XwaHookDialog.cs
@@ -974,17 +974,30 @@ namespace Idmr.Yogeme
 				if (parts.Length == 7) offset = 1;
 				else if (parts.Length != 6) return false;
 
-				ModelIndex = Convert.ToInt32(parts[0], 16);
-				if (offset != 0) Markings = Convert.ToByte(parts[1], 16);
+				ModelIndex = parseInt32(parts[0]);
+				if (offset != 0) Markings = Convert.ToByte(parseInt32(parts[1]) & 0xFF);
 				else Markings = 0;
-				PositionX = Convert.ToInt32(parts[1 + offset], 16);
-				PositionY = Convert.ToInt32(parts[2 + offset], 16);
+				PositionX = parseInt32(parts[1 + offset]);
+				PositionY = parseInt32(parts[2 + offset]);
 				IsGrounded = (parts[3 + offset].ToLower() == "0x7fffffff");
-				if (!IsGrounded) PositionZ = Convert.ToInt32(parts[3 + offset], 16);
-				HeadingXY = Convert.ToInt32(parts[4 + offset], 16);
-				HeadingZ = Convert.ToInt32(parts[5 + offset], 16);
+				if (!IsGrounded) PositionZ = parseInt32(parts[3 + offset]);
+				HeadingXY = parseInt32(parts[4 + offset]);
+				HeadingZ = parseInt32(parts[5 + offset]);
 
 				return true;
+			}
+
+			private int parseInt32(string token)
+			{
+				// Using this because Convert.ToInt32 was throwing an exception on signed integers.
+				token = token.Trim();
+				int result = 0;
+				if (token.StartsWith("0x") && Int32.TryParse(token.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out result))
+					return result;
+				if (Int32.TryParse(token, System.Globalization.NumberStyles.Integer, null, out result))
+					return result;
+				Int32.TryParse(token, System.Globalization.NumberStyles.HexNumber, null, out result);
+				return result;
 			}
 		}
 	}

--- a/XwaHookDialog.cs
+++ b/XwaHookDialog.cs
@@ -405,6 +405,7 @@ namespace Idmr.Yogeme
 
 			chkBackdrops.Checked = (lstBackdrops.Items.Count > 0);
 			chkMission.Checked = (lstMission.Items.Count > 0);
+			chkSounds.Checked = (lstSounds.Items.Count > 0);
 			chkObjects.Checked = (lstObjects.Items.Count > 0);
 			chkHangars.Checked = useHangarObjects | useHangarCamera | useFamilyHangarCamera | useHangarMap;
 		}

--- a/XwaHookDialog.cs
+++ b/XwaHookDialog.cs
@@ -61,7 +61,7 @@ namespace Idmr.Yogeme
 				cmdCancel_Click("NewMission", new EventArgs());
 				return;
 			}
-			_fileName = mission.MissionPath.Replace(".tie", ".ini");
+			_fileName = mission.MissionPath.ToLower().Replace(".tie", ".ini");
 
 			#region initialize
 			cboIff.Items.AddRange(Strings.IFF);

--- a/XwaHookDialog.cs
+++ b/XwaHookDialog.cs
@@ -405,6 +405,7 @@ namespace Idmr.Yogeme
 
 			chkBackdrops.Checked = (lstBackdrops.Items.Count > 0);
 			chkMission.Checked = (lstMission.Items.Count > 0);
+			chkObjects.Checked = (lstObjects.Items.Count > 0);
 			chkHangars.Checked = useHangarObjects | useHangarCamera | useFamilyHangarCamera | useHangarMap;
 		}
 
@@ -785,6 +786,7 @@ namespace Idmr.Yogeme
 			if (!chkMission.Checked && _missionTxtFile != "") File.Delete(_missionTxtFile);
 
 			if (!chkSounds.Checked && _soundFile != "") File.Delete(_soundFile);
+			if (!chkObjects.Checked && _objFile != "") File.Delete(_objFile);
 
 			if (!useHangarObjects && _hangarObjectsFile != "") File.Delete(_hangarObjectsFile);
 			if (!useHangarCamera && _hangarCameraFile != "") File.Delete(_hangarCameraFile);
@@ -792,7 +794,7 @@ namespace Idmr.Yogeme
 			if (!useHangarMap && _hangarMapFile != "") File.Delete(_hangarMapFile);
 			if (!useFamilyHangarMap && _famHangarMapFile != "") File.Delete(_famHangarMapFile);
 
-			if (!chkBackdrops.Checked && !chkMission.Checked && !chkSounds.Checked && !useHangarObjects && !useHangarCamera && !useFamilyHangarCamera && !useHangarMap && !useFamilyHangarMap)
+			if (!chkBackdrops.Checked && !chkMission.Checked && !chkSounds.Checked && !chkObjects.Checked && !useHangarObjects && !useHangarCamera && !useFamilyHangarCamera && !useHangarMap && !useFamilyHangarMap)
 			{
 				File.Delete(_fileName);
 				Close();
@@ -853,6 +855,12 @@ namespace Idmr.Yogeme
 				{
 					sw.WriteLine("[Sounds]");
 					for (int i = 0; i < lstSounds.Items.Count; i++) sw.WriteLine(lstSounds.Items[i]);
+					sw.WriteLine("");
+				}
+				if (chkObjects.Checked && lstObjects.Items.Count > 0)
+				{
+					sw.WriteLine("[Objects]");
+					for (int i = 0; i < lstObjects.Items.Count; i++) sw.WriteLine(lstObjects.Items[i]);
 					sw.WriteLine("");
 				}
 				if (chkHangars.Checked)
@@ -926,6 +934,7 @@ namespace Idmr.Yogeme
 				if (_bdFile != "") File.Delete(_bdFile);
 				if (_missionTxtFile != "") File.Delete(_missionTxtFile);
 				if (_soundFile != "") File.Delete(_soundFile);
+				if (_objFile != "") File.Delete(_objFile);
 				if (_hangarObjectsFile != "") File.Delete(_hangarObjectsFile);
 				if (_hangarCameraFile != "") File.Delete(_hangarCameraFile);
 				if (_famHangarCameraFile != "") File.Delete(_famHangarCameraFile);

--- a/XwingForm.Designer.cs
+++ b/XwingForm.Designer.cs
@@ -226,6 +226,7 @@ namespace Idmr.Yogeme
 			this.savXW = new System.Windows.Forms.SaveFileDialog();
 			this.dataWaypoints = new System.Data.DataView();
 			this.dataWaypointsRaw = new System.Data.DataView();
+			this.menuLibrary = new System.Windows.Forms.MenuItem();
 			this.tabMain.SuspendLayout();
 			this.tabFG.SuspendLayout();
 			this.tabFGMinor.SuspendLayout();
@@ -2148,7 +2149,8 @@ namespace Idmr.Yogeme
             this.menuMap,
             this.menuBriefing,
             this.menuOptions,
-            this.menuGoalSummary});
+            this.menuGoalSummary,
+            this.menuLibrary});
 			this.menuTools.Text = "&Tools";
 			// 
 			// menuVerify
@@ -2245,6 +2247,12 @@ namespace Idmr.Yogeme
 			// 
 			this.dataWaypointsRaw.AllowDelete = false;
 			this.dataWaypointsRaw.AllowNew = false;
+			// 
+			// menuLibrary
+			// 
+			this.menuLibrary.Index = 5;
+			this.menuLibrary.Text = "FG Librar&y";
+			this.menuLibrary.Click += new System.EventHandler(this.menuLibrary_Click);
 			// 
 			// XwingForm
 			// 
@@ -2525,5 +2533,6 @@ namespace Idmr.Yogeme
 		private MenuItem menuSaveAsXwing;
 		System.Data.DataView dataWaypoints;
 		System.Data.DataView dataWaypointsRaw;
+		private MenuItem menuLibrary;
 	}
 }

--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -70,6 +70,7 @@ namespace Idmr.Yogeme
 		
 		MapForm _fMap;
 		BriefingFormXwing _fBrief;
+		FlightGroupLibraryForm _fLibrary;
 		#endregion
 		#region Control Arrays
 #pragma warning disable IDE1006 // Naming Styles
@@ -109,6 +110,8 @@ namespace Idmr.Yogeme
 			try { _fMap.Close(); }
 			catch { /* do nothing */ }
 			try { _fBrief.Close(); }
+			catch { /* do nothing */ }
+			try { _fLibrary.Close(); }
 			catch { /* do nothing */ }
 		}
 		void comboLoadIndex(ComboBox cbo, int index, bool nullable)
@@ -846,6 +849,26 @@ namespace Idmr.Yogeme
 				if (dsGoal.Length > 0) dsGoal += "\r\n\r\n";
 			}
 			new GoalSummaryDialog(dsGoal + generateGoalSummary()).Show();
+		}
+		void menuLibrary_Click(object sender, EventArgs e)
+		{
+			if (_fLibrary != null)
+				_fLibrary.Close();
+			_fLibrary = new FlightGroupLibraryForm(Settings.Platform.XWING, _mission.FlightGroups, flightGroupLibraryCallback);
+		}
+		void flightGroupLibraryCallback(object sender, EventArgs e)
+		{
+			foreach (FlightGroup fg in (object[])sender)
+			{
+				if (fg == null)
+					break;
+				newFG(fg.IsFlightGroup());
+				_mission.FlightGroups[_activeFG] = fg;
+				updateFGList();
+				listRefresh();
+				_startingShips--;
+				craftStart(fg, true);
+			}
 		}
 		void menuHelpInfo_Click(object sender, EventArgs e)
 		{


### PR DESCRIPTION
With these changes, the XvT platform is mostly feature complete.  Added a new craft tab in the XvT editor to handle the new Arr/Dep (well really just Arr) options.  Removed old unknowns.  I'm considering moving the "abort on mission clock" departure controls (also former unknowns) here since it's usefulness is limited and it crowds up space in the normal Arr/Dep tab.

As a feature request, XWA GlobalGroup names are now implemented into trigger text and GG dropdowns.

Another feature request, a FlightGroup library similar to AlliED.  It stores FGs independently from the mission, and they can be added to missions on-demand.  Works for all platforms.

Several issues were fixed in the XWA hook dialog.  Notably the HangarMap section was saving values as integers, but loading as hex, corrupting the data.  A secondary bug would not allow negative values when loading hex.  Modified the parser to handle "0x" prefix first then handle as integer.  I'm not sure if there's any further intent on handling hex values, but I allowed parsing it as a last resort just to be safe.

Note: XvtForm.resx has a potentially bad commit concerning the multiline label text in the new Arr/Dep tab.  I changed the text from a previous commit (which I forgot about), but when staging this file, I erroneously only staged the added lines without removing the originals.  May need to be fixed manually.