### PR TITLE
Map interface revision and many new features

### DIFF
--- a/BriefingForm.cs
+++ b/BriefingForm.cs
@@ -541,8 +541,12 @@ namespace Idmr.Yogeme
 		void frmBrief_FormClosing(object sender, FormClosingEventArgs e)
 		{
 			Save();
-			tmrPopup.Stop(); //[JB] Stop and deactivate the timers.  Hopefully this fixes a rare exception (possibly a race condition?) where the newly implemented redraw event would still try to repaint the map even after everything was disposed.
+			//[JB] Stop and deactivate the timers.
+			//Important! There's an issue where the event can trigger after the map is disposed, even after calling Stop(). The event must be unregistered.
+			tmrPopup.Stop();
+			tmrPopup.Tick -= tmrPopup_Tick;
 			tmrMapRedraw.Stop();
+			tmrMapRedraw.Tick -= tmrMapRedraw_Tick;
 			onModified = null;
 		}
 		void frmBrief_Load(object sender, EventArgs e)

--- a/MapForm.Designer.cs
+++ b/MapForm.Designer.cs
@@ -59,29 +59,54 @@ namespace Idmr.Yogeme
 			this.numRegion = new System.Windows.Forms.NumericUpDown();
 			this.lblOrder = new System.Windows.Forms.Label();
 			this.numOrder = new System.Windows.Forms.NumericUpDown();
-			this.label1 = new System.Windows.Forms.Label();
-			this.lstVisible = new System.Windows.Forms.ListBox();
-			this.label3 = new System.Windows.Forms.Label();
+			this.lstCraft = new System.Windows.Forms.ListBox();
 			this.cmdHideNone = new System.Windows.Forms.Button();
-			this.cmdHideAll = new System.Windows.Forms.Button();
-			this.lstSelected = new System.Windows.Forms.ListBox();
-			this.lblQuickHide = new System.Windows.Forms.Label();
+			this.lstSelection = new System.Windows.Forms.ListBox();
+			this.lblSelection = new System.Windows.Forms.Label();
 			this.cmdHelp = new System.Windows.Forms.Button();
 			this.chkDistance = new System.Windows.Forms.CheckBox();
 			this.mapPaintRedrawTimer = new System.Windows.Forms.Timer(this.components);
+			this.lblFade = new System.Windows.Forms.Label();
+			this.cmdFadeAdd = new System.Windows.Forms.Button();
+			this.cmdFadeNone = new System.Windows.Forms.Button();
+			this.cmdFadeSubtract = new System.Windows.Forms.Button();
+			this.lblHide = new System.Windows.Forms.Label();
+			this.cmdHideAdd = new System.Windows.Forms.Button();
+			this.cmdHideSubtract = new System.Windows.Forms.Button();
+			this.cboSnapUnit = new System.Windows.Forms.ComboBox();
+			this.lblSnapTo = new System.Windows.Forms.Label();
+			this.cboSnapTo = new System.Windows.Forms.ComboBox();
+			this.numSnapAmount = new System.Windows.Forms.NumericUpDown();
+			this.lblExpandSelection = new System.Windows.Forms.Label();
+			this.cmdExpandByCraft = new System.Windows.Forms.Button();
+			this.cmdExpandByIff = new System.Windows.Forms.Button();
+			this.cmdExpandBySize = new System.Windows.Forms.Button();
+			this.cmdInvertSelection = new System.Windows.Forms.Button();
+			this.chkTime = new System.Windows.Forms.CheckBox();
+			this.chkTraceHideFade = new System.Windows.Forms.CheckBox();
+			this.chkTraceSelected = new System.Windows.Forms.CheckBox();
+			this.cmdFitSelected = new System.Windows.Forms.Button();
+			this.lblFit = new System.Windows.Forms.Label();
+			this.cmdFitWorld = new System.Windows.Forms.Button();
+			this.cmdFitDefault = new System.Windows.Forms.Button();
+			this.lblCenterOn = new System.Windows.Forms.Label();
+			this.cmdCenterSelected = new System.Windows.Forms.Button();
+			this.cboViewDifficulty = new System.Windows.Forms.ComboBox();
+			this.cboViewIff = new System.Windows.Forms.ComboBox();
 			((System.ComponentModel.ISupportInitialize)(this.pctMap)).BeginInit();
 			this.grpDir.SuspendLayout();
 			this.grpPoints.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numRegion)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numOrder)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numSnapAmount)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// pctMap
 			// 
 			this.pctMap.BackColor = System.Drawing.Color.Black;
-			this.pctMap.Location = new System.Drawing.Point(102, 64);
+			this.pctMap.Location = new System.Drawing.Point(122, 64);
 			this.pctMap.Name = "pctMap";
-			this.pctMap.Size = new System.Drawing.Size(642, 408);
+			this.pctMap.Size = new System.Drawing.Size(622, 408);
 			this.pctMap.TabIndex = 28;
 			this.pctMap.TabStop = false;
 			this.pctMap.Paint += new System.Windows.Forms.PaintEventHandler(this.pctMap_Paint);
@@ -94,26 +119,26 @@ namespace Idmr.Yogeme
 			// 
 			// hscZoom
 			// 
-			this.hscZoom.Location = new System.Drawing.Point(402, 504);
+			this.hscZoom.Location = new System.Drawing.Point(290, 504);
 			this.hscZoom.Maximum = 2000;
 			this.hscZoom.Minimum = 5;
 			this.hscZoom.Name = "hscZoom";
 			this.hscZoom.Size = new System.Drawing.Size(342, 16);
-			this.hscZoom.TabIndex = 30;
+			this.hscZoom.TabIndex = 58;
 			this.hscZoom.Value = 40;
 			this.hscZoom.ValueChanged += new System.EventHandler(this.hscZoom_ValueChanged);
 			// 
 			// lblCoor1
 			// 
-			this.lblCoor1.Location = new System.Drawing.Point(24, 504);
+			this.lblCoor1.Location = new System.Drawing.Point(15, 504);
 			this.lblCoor1.Name = "lblCoor1";
-			this.lblCoor1.Size = new System.Drawing.Size(72, 16);
+			this.lblCoor1.Size = new System.Drawing.Size(96, 16);
 			this.lblCoor1.TabIndex = 27;
 			this.lblCoor1.Text = "X:";
 			// 
 			// lblCoor2
 			// 
-			this.lblCoor2.Location = new System.Drawing.Point(120, 504);
+			this.lblCoor2.Location = new System.Drawing.Point(110, 504);
 			this.lblCoor2.Name = "lblCoor2";
 			this.lblCoor2.Size = new System.Drawing.Size(96, 16);
 			this.lblCoor2.TabIndex = 26;
@@ -121,7 +146,7 @@ namespace Idmr.Yogeme
 			// 
 			// lblZoom
 			// 
-			this.lblZoom.Location = new System.Drawing.Point(322, 504);
+			this.lblZoom.Location = new System.Drawing.Point(212, 504);
 			this.lblZoom.Name = "lblZoom";
 			this.lblZoom.Size = new System.Drawing.Size(64, 16);
 			this.lblZoom.TabIndex = 25;
@@ -143,7 +168,7 @@ namespace Idmr.Yogeme
 			this.grpDir.Controls.Add(this.optXY);
 			this.grpDir.Controls.Add(this.optXZ);
 			this.grpDir.Controls.Add(this.optYZ);
-			this.grpDir.Location = new System.Drawing.Point(750, 12);
+			this.grpDir.Location = new System.Drawing.Point(750, 3);
 			this.grpDir.Name = "grpDir";
 			this.grpDir.Size = new System.Drawing.Size(64, 84);
 			this.grpDir.TabIndex = 0;
@@ -202,7 +227,7 @@ namespace Idmr.Yogeme
 			this.grpPoints.Controls.Add(this.chkBRF3);
 			this.grpPoints.Controls.Add(this.chkBRF2);
 			this.grpPoints.Controls.Add(this.chkBRF);
-			this.grpPoints.Location = new System.Drawing.Point(750, 100);
+			this.grpPoints.Location = new System.Drawing.Point(750, 97);
 			this.grpPoints.Name = "grpPoints";
 			this.grpPoints.Size = new System.Drawing.Size(64, 362);
 			this.grpPoints.TabIndex = 5;
@@ -390,9 +415,10 @@ namespace Idmr.Yogeme
 			// 
 			this.chkTags.Checked = true;
 			this.chkTags.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chkTags.Location = new System.Drawing.Point(750, 468);
+			this.chkTags.Location = new System.Drawing.Point(750, 465);
+			this.chkTags.Margin = new System.Windows.Forms.Padding(0);
 			this.chkTags.Name = "chkTags";
-			this.chkTags.Size = new System.Drawing.Size(72, 24);
+			this.chkTags.Size = new System.Drawing.Size(72, 17);
 			this.chkTags.TabIndex = 28;
 			this.chkTags.Text = "FG Tags";
 			this.chkTags.CheckedChanged += new System.EventHandler(this.chkTags_CheckedChanged);
@@ -401,9 +427,10 @@ namespace Idmr.Yogeme
 			// 
 			this.chkTrace.Checked = true;
 			this.chkTrace.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chkTrace.Location = new System.Drawing.Point(750, 487);
+			this.chkTrace.Location = new System.Drawing.Point(750, 482);
+			this.chkTrace.Margin = new System.Windows.Forms.Padding(0);
 			this.chkTrace.Name = "chkTrace";
-			this.chkTrace.Size = new System.Drawing.Size(72, 24);
+			this.chkTrace.Size = new System.Drawing.Size(92, 17);
 			this.chkTrace.TabIndex = 29;
 			this.chkTrace.Text = "Traces";
 			this.chkTrace.CheckedChanged += new System.EventHandler(this.chkTrace_CheckedChanged);
@@ -411,7 +438,7 @@ namespace Idmr.Yogeme
 			// lblRegion
 			// 
 			this.lblRegion.AutoSize = true;
-			this.lblRegion.Location = new System.Drawing.Point(572, 28);
+			this.lblRegion.Location = new System.Drawing.Point(657, 11);
 			this.lblRegion.Name = "lblRegion";
 			this.lblRegion.Size = new System.Drawing.Size(44, 13);
 			this.lblRegion.TabIndex = 31;
@@ -420,7 +447,7 @@ namespace Idmr.Yogeme
 			// 
 			// numRegion
 			// 
-			this.numRegion.Location = new System.Drawing.Point(622, 26);
+			this.numRegion.Location = new System.Drawing.Point(707, 9);
 			this.numRegion.Maximum = new decimal(new int[] {
             4,
             0,
@@ -433,7 +460,7 @@ namespace Idmr.Yogeme
             0});
 			this.numRegion.Name = "numRegion";
 			this.numRegion.Size = new System.Drawing.Size(33, 20);
-			this.numRegion.TabIndex = 32;
+			this.numRegion.TabIndex = 35;
 			this.numRegion.Value = new decimal(new int[] {
             1,
             0,
@@ -445,7 +472,7 @@ namespace Idmr.Yogeme
 			// lblOrder
 			// 
 			this.lblOrder.AutoSize = true;
-			this.lblOrder.Location = new System.Drawing.Point(669, 28);
+			this.lblOrder.Location = new System.Drawing.Point(568, 11);
 			this.lblOrder.Name = "lblOrder";
 			this.lblOrder.Size = new System.Drawing.Size(36, 13);
 			this.lblOrder.TabIndex = 31;
@@ -454,7 +481,7 @@ namespace Idmr.Yogeme
 			// 
 			// numOrder
 			// 
-			this.numOrder.Location = new System.Drawing.Point(711, 26);
+			this.numOrder.Location = new System.Drawing.Point(610, 9);
 			this.numOrder.Maximum = new decimal(new int[] {
             4,
             0,
@@ -467,7 +494,7 @@ namespace Idmr.Yogeme
             0});
 			this.numOrder.Name = "numOrder";
 			this.numOrder.Size = new System.Drawing.Size(33, 20);
-			this.numOrder.TabIndex = 32;
+			this.numOrder.TabIndex = 34;
 			this.numOrder.Value = new decimal(new int[] {
             1,
             0,
@@ -476,99 +503,72 @@ namespace Idmr.Yogeme
 			this.numOrder.Visible = false;
 			this.numOrder.ValueChanged += new System.EventHandler(this.numOrder_ValueChanged);
 			// 
-			// label1
+			// lstCraft
 			// 
-			this.label1.Location = new System.Drawing.Point(47, 9);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(223, 27);
-			this.label1.TabIndex = 33;
-			this.label1.Text = "Click to view mouse and keyboard commands to edit and navigate the map.";
-			// 
-			// lstVisible
-			// 
-			this.lstVisible.BackColor = System.Drawing.Color.Black;
-			this.lstVisible.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
-			this.lstVisible.ForeColor = System.Drawing.Color.Gray;
-			this.lstVisible.FormattingEnabled = true;
-			this.lstVisible.Location = new System.Drawing.Point(2, 116);
-			this.lstVisible.Name = "lstVisible";
-			this.lstVisible.SelectionMode = System.Windows.Forms.SelectionMode.MultiSimple;
-			this.lstVisible.Size = new System.Drawing.Size(94, 355);
-			this.lstVisible.TabIndex = 34;
-			this.lstVisible.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lstVisible_DrawItem);
-			this.lstVisible.SelectedIndexChanged += new System.EventHandler(this.lstVisible_SelectedIndexChanged);
-			// 
-			// label3
-			// 
-			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(-1, 76);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(32, 13);
-			this.label3.TabIndex = 36;
-			this.label3.Text = "Hide:";
+			this.lstCraft.BackColor = System.Drawing.Color.Black;
+			this.lstCraft.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
+			this.lstCraft.ForeColor = System.Drawing.Color.Gray;
+			this.lstCraft.FormattingEnabled = true;
+			this.lstCraft.Location = new System.Drawing.Point(2, 64);
+			this.lstCraft.Name = "lstCraft";
+			this.lstCraft.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+			this.lstCraft.Size = new System.Drawing.Size(114, 407);
+			this.lstCraft.TabIndex = 50;
+			this.lstCraft.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lstCraft_DrawItem);
+			this.lstCraft.SelectedIndexChanged += new System.EventHandler(this.lstCraft_SelectedIndexChanged);
 			// 
 			// cmdHideNone
 			// 
 			this.cmdHideNone.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.cmdHideNone.Location = new System.Drawing.Point(2, 92);
+			this.cmdHideNone.Location = new System.Drawing.Point(413, 35);
 			this.cmdHideNone.Name = "cmdHideNone";
-			this.cmdHideNone.Size = new System.Drawing.Size(42, 23);
-			this.cmdHideNone.TabIndex = 37;
+			this.cmdHideNone.Size = new System.Drawing.Size(42, 22);
+			this.cmdHideNone.TabIndex = 44;
 			this.cmdHideNone.Text = "None";
 			this.cmdHideNone.UseVisualStyleBackColor = true;
 			this.cmdHideNone.Click += new System.EventHandler(this.cmdHideNone_Click);
 			// 
-			// cmdHideAll
+			// lstSelection
 			// 
-			this.cmdHideAll.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.cmdHideAll.Location = new System.Drawing.Point(50, 92);
-			this.cmdHideAll.Name = "cmdHideAll";
-			this.cmdHideAll.Size = new System.Drawing.Size(42, 23);
-			this.cmdHideAll.TabIndex = 37;
-			this.cmdHideAll.Text = "All";
-			this.cmdHideAll.UseVisualStyleBackColor = true;
-			this.cmdHideAll.Click += new System.EventHandler(this.cmdHideAll_Click);
+			this.lstSelection.BackColor = System.Drawing.Color.Black;
+			this.lstSelection.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
+			this.lstSelection.ForeColor = System.Drawing.Color.Gray;
+			this.lstSelection.FormattingEnabled = true;
+			this.lstSelection.Location = new System.Drawing.Point(122, 81);
+			this.lstSelection.Name = "lstSelection";
+			this.lstSelection.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+			this.lstSelection.Size = new System.Drawing.Size(134, 17);
+			this.lstSelection.TabIndex = 51;
+			this.lstSelection.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lstSelection_DrawItem);
+			this.lstSelection.SelectedIndexChanged += new System.EventHandler(this.lstSelection_SelectedIndexChanged);
 			// 
-			// lstSelected
+			// lblSelection
 			// 
-			this.lstSelected.BackColor = System.Drawing.Color.Black;
-			this.lstSelected.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
-			this.lstSelected.ForeColor = System.Drawing.Color.Gray;
-			this.lstSelected.FormattingEnabled = true;
-			this.lstSelected.Location = new System.Drawing.Point(102, 76);
-			this.lstSelected.Name = "lstSelected";
-			this.lstSelected.SelectionMode = System.Windows.Forms.SelectionMode.MultiSimple;
-			this.lstSelected.Size = new System.Drawing.Size(94, 17);
-			this.lstSelected.TabIndex = 38;
-			this.lstSelected.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lstSelected_DrawItem);
-			this.lstSelected.SelectedIndexChanged += new System.EventHandler(this.lstSelected_SelectedIndexChanged);
-			// 
-			// lblQuickHide
-			// 
-			this.lblQuickHide.AutoSize = true;
-			this.lblQuickHide.Location = new System.Drawing.Point(99, 64);
-			this.lblQuickHide.Name = "lblQuickHide";
-			this.lblQuickHide.Size = new System.Drawing.Size(79, 13);
-			this.lblQuickHide.TabIndex = 39;
-			this.lblQuickHide.Text = "Hide Selection:";
+			this.lblSelection.AutoSize = true;
+			this.lblSelection.Location = new System.Drawing.Point(120, 64);
+			this.lblSelection.Name = "lblSelection";
+			this.lblSelection.Size = new System.Drawing.Size(54, 13);
+			this.lblSelection.TabIndex = 39;
+			this.lblSelection.Text = "Selection:";
 			// 
 			// cmdHelp
 			// 
-			this.cmdHelp.Location = new System.Drawing.Point(2, 9);
+			this.cmdHelp.Location = new System.Drawing.Point(2, 3);
 			this.cmdHelp.Name = "cmdHelp";
-			this.cmdHelp.Size = new System.Drawing.Size(42, 23);
-			this.cmdHelp.TabIndex = 40;
+			this.cmdHelp.Size = new System.Drawing.Size(38, 21);
+			this.cmdHelp.TabIndex = 49;
 			this.cmdHelp.Text = "Help";
+			this.cmdHelp.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.cmdHelp.UseVisualStyleBackColor = true;
 			this.cmdHelp.Click += new System.EventHandler(this.cmdHelp_Click);
 			// 
 			// chkDistance
 			// 
-			this.chkDistance.AutoSize = true;
-			this.chkDistance.Location = new System.Drawing.Point(750, 506);
+			this.chkDistance.Location = new System.Drawing.Point(750, 499);
+			this.chkDistance.Margin = new System.Windows.Forms.Padding(0);
 			this.chkDistance.Name = "chkDistance";
 			this.chkDistance.Size = new System.Drawing.Size(68, 17);
-			this.chkDistance.TabIndex = 41;
+			this.chkDistance.TabIndex = 30;
 			this.chkDistance.Text = "Distance";
 			this.chkDistance.UseVisualStyleBackColor = true;
 			this.chkDistance.CheckedChanged += new System.EventHandler(this.chkDistance_CheckedChanged);
@@ -578,25 +578,356 @@ namespace Idmr.Yogeme
 			this.mapPaintRedrawTimer.Interval = 17;
 			this.mapPaintRedrawTimer.Tick += new System.EventHandler(this.mapPaintRedrawTimer_Tick);
 			// 
+			// lblFade
+			// 
+			this.lblFade.AutoSize = true;
+			this.lblFade.Location = new System.Drawing.Point(282, 17);
+			this.lblFade.Name = "lblFade";
+			this.lblFade.Size = new System.Drawing.Size(73, 13);
+			this.lblFade.TabIndex = 42;
+			this.lblFade.Text = "Faded: 0 craft";
+			// 
+			// cmdFadeAdd
+			// 
+			this.cmdFadeAdd.Location = new System.Drawing.Point(361, 12);
+			this.cmdFadeAdd.Name = "cmdFadeAdd";
+			this.cmdFadeAdd.Size = new System.Drawing.Size(20, 22);
+			this.cmdFadeAdd.TabIndex = 39;
+			this.cmdFadeAdd.Text = "+";
+			this.cmdFadeAdd.UseVisualStyleBackColor = true;
+			this.cmdFadeAdd.Click += new System.EventHandler(this.cmdFadeAdd_Click);
+			// 
+			// cmdFadeNone
+			// 
+			this.cmdFadeNone.Location = new System.Drawing.Point(413, 12);
+			this.cmdFadeNone.Name = "cmdFadeNone";
+			this.cmdFadeNone.Size = new System.Drawing.Size(42, 22);
+			this.cmdFadeNone.TabIndex = 41;
+			this.cmdFadeNone.Text = "None";
+			this.cmdFadeNone.UseVisualStyleBackColor = true;
+			this.cmdFadeNone.Click += new System.EventHandler(this.cmdFadeNone_Click);
+			// 
+			// cmdFadeSubtract
+			// 
+			this.cmdFadeSubtract.Location = new System.Drawing.Point(387, 12);
+			this.cmdFadeSubtract.Name = "cmdFadeSubtract";
+			this.cmdFadeSubtract.Size = new System.Drawing.Size(20, 22);
+			this.cmdFadeSubtract.TabIndex = 40;
+			this.cmdFadeSubtract.Text = "-";
+			this.cmdFadeSubtract.UseVisualStyleBackColor = true;
+			this.cmdFadeSubtract.Click += new System.EventHandler(this.cmdFadeSubtract_Click);
+			// 
+			// lblHide
+			// 
+			this.lblHide.AutoSize = true;
+			this.lblHide.Location = new System.Drawing.Point(278, 40);
+			this.lblHide.Name = "lblHide";
+			this.lblHide.Size = new System.Drawing.Size(77, 13);
+			this.lblHide.TabIndex = 42;
+			this.lblHide.Text = "Hidden: 0 craft";
+			// 
+			// cmdHideAdd
+			// 
+			this.cmdHideAdd.Location = new System.Drawing.Point(361, 35);
+			this.cmdHideAdd.Name = "cmdHideAdd";
+			this.cmdHideAdd.Size = new System.Drawing.Size(20, 22);
+			this.cmdHideAdd.TabIndex = 42;
+			this.cmdHideAdd.Text = "+";
+			this.cmdHideAdd.UseVisualStyleBackColor = true;
+			this.cmdHideAdd.Click += new System.EventHandler(this.cmdHideAdd_Click);
+			// 
+			// cmdHideSubtract
+			// 
+			this.cmdHideSubtract.Location = new System.Drawing.Point(387, 35);
+			this.cmdHideSubtract.Name = "cmdHideSubtract";
+			this.cmdHideSubtract.Size = new System.Drawing.Size(20, 22);
+			this.cmdHideSubtract.TabIndex = 43;
+			this.cmdHideSubtract.Text = "-";
+			this.cmdHideSubtract.UseVisualStyleBackColor = true;
+			this.cmdHideSubtract.Click += new System.EventHandler(this.cmdHideSubtract_Click);
+			// 
+			// cboSnapUnit
+			// 
+			this.cboSnapUnit.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboSnapUnit.FormattingEnabled = true;
+			this.cboSnapUnit.Items.AddRange(new object[] {
+            "KM",
+            "Raw"});
+			this.cboSnapUnit.Location = new System.Drawing.Point(692, 37);
+			this.cboSnapUnit.Name = "cboSnapUnit";
+			this.cboSnapUnit.Size = new System.Drawing.Size(52, 21);
+			this.cboSnapUnit.TabIndex = 38;
+			this.cboSnapUnit.SelectedIndexChanged += new System.EventHandler(this.cboSnapUnit_SelectedIndexChanged);
+			// 
+			// lblSnapTo
+			// 
+			this.lblSnapTo.AutoSize = true;
+			this.lblSnapTo.Location = new System.Drawing.Point(521, 40);
+			this.lblSnapTo.Name = "lblSnapTo";
+			this.lblSnapTo.Size = new System.Drawing.Size(47, 13);
+			this.lblSnapTo.TabIndex = 47;
+			this.lblSnapTo.Text = "Snap to:";
+			// 
+			// cboSnapTo
+			// 
+			this.cboSnapTo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboSnapTo.FormattingEnabled = true;
+			this.cboSnapTo.Items.AddRange(new object[] {
+            "None",
+            "Self",
+            "Grid"});
+			this.cboSnapTo.Location = new System.Drawing.Point(574, 37);
+			this.cboSnapTo.Name = "cboSnapTo";
+			this.cboSnapTo.Size = new System.Drawing.Size(56, 21);
+			this.cboSnapTo.TabIndex = 36;
+			this.cboSnapTo.SelectedIndexChanged += new System.EventHandler(this.cboSnapTo_SelectedIndexChanged);
+			// 
+			// numSnapAmount
+			// 
+			this.numSnapAmount.DecimalPlaces = 2;
+			this.numSnapAmount.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+			this.numSnapAmount.Location = new System.Drawing.Point(636, 38);
+			this.numSnapAmount.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            131072});
+			this.numSnapAmount.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+			this.numSnapAmount.Name = "numSnapAmount";
+			this.numSnapAmount.Size = new System.Drawing.Size(50, 20);
+			this.numSnapAmount.TabIndex = 37;
+			this.numSnapAmount.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            131072});
+			// 
+			// lblExpandSelection
+			// 
+			this.lblExpandSelection.AutoSize = true;
+			this.lblExpandSelection.Location = new System.Drawing.Point(134, 18);
+			this.lblExpandSelection.Name = "lblExpandSelection";
+			this.lblExpandSelection.Size = new System.Drawing.Size(105, 13);
+			this.lblExpandSelection.TabIndex = 49;
+			this.lblExpandSelection.Text = "Expand selection by:";
+			// 
+			// cmdExpandByCraft
+			// 
+			this.cmdExpandByCraft.Location = new System.Drawing.Point(137, 35);
+			this.cmdExpandByCraft.Margin = new System.Windows.Forms.Padding(0);
+			this.cmdExpandByCraft.Name = "cmdExpandByCraft";
+			this.cmdExpandByCraft.Size = new System.Drawing.Size(39, 23);
+			this.cmdExpandByCraft.TabIndex = 46;
+			this.cmdExpandByCraft.Text = "Craft";
+			this.cmdExpandByCraft.UseVisualStyleBackColor = true;
+			this.cmdExpandByCraft.Click += new System.EventHandler(this.cmdExpandByCraft_Click);
+			// 
+			// cmdExpandByIff
+			// 
+			this.cmdExpandByIff.Location = new System.Drawing.Point(176, 35);
+			this.cmdExpandByIff.Margin = new System.Windows.Forms.Padding(0);
+			this.cmdExpandByIff.Name = "cmdExpandByIff";
+			this.cmdExpandByIff.Size = new System.Drawing.Size(39, 23);
+			this.cmdExpandByIff.TabIndex = 47;
+			this.cmdExpandByIff.Text = "IFF";
+			this.cmdExpandByIff.UseVisualStyleBackColor = true;
+			this.cmdExpandByIff.Click += new System.EventHandler(this.cmdExpandByIff_Click);
+			// 
+			// cmdExpandBySize
+			// 
+			this.cmdExpandBySize.Location = new System.Drawing.Point(215, 35);
+			this.cmdExpandBySize.Margin = new System.Windows.Forms.Padding(0);
+			this.cmdExpandBySize.Name = "cmdExpandBySize";
+			this.cmdExpandBySize.Size = new System.Drawing.Size(39, 23);
+			this.cmdExpandBySize.TabIndex = 48;
+			this.cmdExpandBySize.Text = "Size";
+			this.cmdExpandBySize.UseVisualStyleBackColor = true;
+			this.cmdExpandBySize.Click += new System.EventHandler(this.cmdExpandBySize_Click);
+			// 
+			// cmdInvertSelection
+			// 
+			this.cmdInvertSelection.Location = new System.Drawing.Point(77, 35);
+			this.cmdInvertSelection.Margin = new System.Windows.Forms.Padding(3, 3, 12, 3);
+			this.cmdInvertSelection.Name = "cmdInvertSelection";
+			this.cmdInvertSelection.Size = new System.Drawing.Size(48, 23);
+			this.cmdInvertSelection.TabIndex = 45;
+			this.cmdInvertSelection.Text = "Invert";
+			this.cmdInvertSelection.UseVisualStyleBackColor = true;
+			this.cmdInvertSelection.Click += new System.EventHandler(this.cmdInvertSelection_Click);
+			// 
+			// chkTime
+			// 
+			this.chkTime.Location = new System.Drawing.Point(750, 516);
+			this.chkTime.Margin = new System.Windows.Forms.Padding(0);
+			this.chkTime.Name = "chkTime";
+			this.chkTime.Size = new System.Drawing.Size(68, 17);
+			this.chkTime.TabIndex = 31;
+			this.chkTime.Text = "Time";
+			this.chkTime.UseVisualStyleBackColor = true;
+			this.chkTime.CheckedChanged += new System.EventHandler(this.chkTime_CheckedChanged);
+			// 
+			// chkTraceHideFade
+			// 
+			this.chkTraceHideFade.Location = new System.Drawing.Point(658, 499);
+			this.chkTraceHideFade.Margin = new System.Windows.Forms.Padding(0);
+			this.chkTraceHideFade.Name = "chkTraceHideFade";
+			this.chkTraceHideFade.Size = new System.Drawing.Size(92, 17);
+			this.chkTraceHideFade.TabIndex = 32;
+			this.chkTraceHideFade.Text = "Hide on fade";
+			this.chkTraceHideFade.UseVisualStyleBackColor = true;
+			this.chkTraceHideFade.CheckedChanged += new System.EventHandler(this.chkTraceHideFade_CheckedChanged);
+			// 
+			// chkTraceSelected
+			// 
+			this.chkTraceSelected.Location = new System.Drawing.Point(658, 516);
+			this.chkTraceSelected.Margin = new System.Windows.Forms.Padding(0);
+			this.chkTraceSelected.Name = "chkTraceSelected";
+			this.chkTraceSelected.Size = new System.Drawing.Size(92, 17);
+			this.chkTraceSelected.TabIndex = 33;
+			this.chkTraceSelected.Text = "Selected only";
+			this.chkTraceSelected.UseVisualStyleBackColor = true;
+			this.chkTraceSelected.CheckedChanged += new System.EventHandler(this.chkTraceSelected_CheckedChanged);
+			// 
+			// cmdFitSelected
+			// 
+			this.cmdFitSelected.Location = new System.Drawing.Point(303, 478);
+			this.cmdFitSelected.Name = "cmdFitSelected";
+			this.cmdFitSelected.Size = new System.Drawing.Size(60, 23);
+			this.cmdFitSelected.TabIndex = 55;
+			this.cmdFitSelected.Text = "Selected";
+			this.cmdFitSelected.UseVisualStyleBackColor = true;
+			this.cmdFitSelected.Click += new System.EventHandler(this.cmdFitSelected_Click);
+			// 
+			// lblFit
+			// 
+			this.lblFit.AutoSize = true;
+			this.lblFit.Location = new System.Drawing.Point(267, 483);
+			this.lblFit.Margin = new System.Windows.Forms.Padding(12, 0, 0, 0);
+			this.lblFit.Name = "lblFit";
+			this.lblFit.Size = new System.Drawing.Size(33, 13);
+			this.lblFit.TabIndex = 54;
+			this.lblFit.Text = "Fit to:";
+			// 
+			// cmdFitWorld
+			// 
+			this.cmdFitWorld.Location = new System.Drawing.Point(369, 478);
+			this.cmdFitWorld.Name = "cmdFitWorld";
+			this.cmdFitWorld.Size = new System.Drawing.Size(60, 23);
+			this.cmdFitWorld.TabIndex = 56;
+			this.cmdFitWorld.Text = "World";
+			this.cmdFitWorld.UseVisualStyleBackColor = true;
+			this.cmdFitWorld.Click += new System.EventHandler(this.cmdFitWorld_Click);
+			// 
+			// cmdFitDefault
+			// 
+			this.cmdFitDefault.Location = new System.Drawing.Point(435, 478);
+			this.cmdFitDefault.Name = "cmdFitDefault";
+			this.cmdFitDefault.Size = new System.Drawing.Size(60, 23);
+			this.cmdFitDefault.TabIndex = 57;
+			this.cmdFitDefault.Text = "Default";
+			this.cmdFitDefault.UseVisualStyleBackColor = true;
+			this.cmdFitDefault.Click += new System.EventHandler(this.cmdFitDefault_Click);
+			// 
+			// lblCenterOn
+			// 
+			this.lblCenterOn.AutoSize = true;
+			this.lblCenterOn.Location = new System.Drawing.Point(137, 483);
+			this.lblCenterOn.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+			this.lblCenterOn.Name = "lblCenterOn";
+			this.lblCenterOn.Size = new System.Drawing.Size(56, 13);
+			this.lblCenterOn.TabIndex = 56;
+			this.lblCenterOn.Text = "Center on:";
+			// 
+			// cmdCenterSelected
+			// 
+			this.cmdCenterSelected.Location = new System.Drawing.Point(196, 478);
+			this.cmdCenterSelected.Name = "cmdCenterSelected";
+			this.cmdCenterSelected.Size = new System.Drawing.Size(60, 23);
+			this.cmdCenterSelected.TabIndex = 54;
+			this.cmdCenterSelected.Text = "Selected";
+			this.cmdCenterSelected.UseVisualStyleBackColor = true;
+			this.cmdCenterSelected.Click += new System.EventHandler(this.cmdCenterSelected_Click);
+			// 
+			// cboViewDifficulty
+			// 
+			this.cboViewDifficulty.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboViewDifficulty.FormattingEnabled = true;
+			this.cboViewDifficulty.Items.AddRange(new object[] {
+            "All Diff",
+            "Easy",
+            "Medium",
+            "Hard"});
+			this.cboViewDifficulty.Location = new System.Drawing.Point(2, 480);
+			this.cboViewDifficulty.Margin = new System.Windows.Forms.Padding(3, 3, 1, 3);
+			this.cboViewDifficulty.Name = "cboViewDifficulty";
+			this.cboViewDifficulty.Size = new System.Drawing.Size(61, 21);
+			this.cboViewDifficulty.TabIndex = 52;
+			this.cboViewDifficulty.SelectedIndexChanged += new System.EventHandler(this.cboViewDifficulty_SelectedIndexChanged);
+			// 
+			// cboViewIff
+			// 
+			this.cboViewIff.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboViewIff.FormattingEnabled = true;
+			this.cboViewIff.Items.AddRange(new object[] {
+            "All IFF"});
+			this.cboViewIff.Location = new System.Drawing.Point(65, 480);
+			this.cboViewIff.Margin = new System.Windows.Forms.Padding(1, 3, 3, 3);
+			this.cboViewIff.Name = "cboViewIff";
+			this.cboViewIff.Size = new System.Drawing.Size(61, 21);
+			this.cboViewIff.TabIndex = 53;
+			this.cboViewIff.SelectedIndexChanged += new System.EventHandler(this.cboViewIff_SelectedIndexChanged);
+			// 
 			// MapForm
 			// 
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.ClientSize = new System.Drawing.Size(824, 535);
+			this.Controls.Add(this.cboViewIff);
+			this.Controls.Add(this.cboViewDifficulty);
+			this.Controls.Add(this.cmdCenterSelected);
+			this.Controls.Add(this.lblCenterOn);
+			this.Controls.Add(this.cmdFitDefault);
+			this.Controls.Add(this.lblFit);
+			this.Controls.Add(this.cmdFitWorld);
+			this.Controls.Add(this.cmdFitSelected);
+			this.Controls.Add(this.chkTraceSelected);
+			this.Controls.Add(this.chkTraceHideFade);
+			this.Controls.Add(this.chkTime);
+			this.Controls.Add(this.cmdInvertSelection);
+			this.Controls.Add(this.cmdExpandBySize);
+			this.Controls.Add(this.grpPoints);
+			this.Controls.Add(this.cmdExpandByIff);
+			this.Controls.Add(this.cmdExpandByCraft);
+			this.Controls.Add(this.lblExpandSelection);
+			this.Controls.Add(this.numSnapAmount);
+			this.Controls.Add(this.lblSnapTo);
+			this.Controls.Add(this.cboSnapTo);
+			this.Controls.Add(this.cboSnapUnit);
+			this.Controls.Add(this.cmdFadeNone);
+			this.Controls.Add(this.cmdHideSubtract);
+			this.Controls.Add(this.cmdFadeSubtract);
+			this.Controls.Add(this.cmdHideAdd);
+			this.Controls.Add(this.cmdFadeAdd);
+			this.Controls.Add(this.lblHide);
+			this.Controls.Add(this.lblFade);
 			this.Controls.Add(this.chkDistance);
 			this.Controls.Add(this.cmdHelp);
-			this.Controls.Add(this.lblQuickHide);
-			this.Controls.Add(this.lstSelected);
-			this.Controls.Add(this.cmdHideAll);
+			this.Controls.Add(this.lblSelection);
+			this.Controls.Add(this.lstSelection);
 			this.Controls.Add(this.cmdHideNone);
-			this.Controls.Add(this.label3);
-			this.Controls.Add(this.lstVisible);
-			this.Controls.Add(this.label1);
+			this.Controls.Add(this.lstCraft);
 			this.Controls.Add(this.numOrder);
 			this.Controls.Add(this.numRegion);
 			this.Controls.Add(this.lblOrder);
 			this.Controls.Add(this.lblRegion);
 			this.Controls.Add(this.chkTags);
-			this.Controls.Add(this.grpPoints);
 			this.Controls.Add(this.grpDir);
 			this.Controls.Add(this.lblZoom);
 			this.Controls.Add(this.lblCoor2);
@@ -607,7 +938,7 @@ namespace Idmr.Yogeme
 			this.DoubleBuffered = true;
 			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
 			this.KeyPreview = true;
-			this.MinimumSize = new System.Drawing.Size(700, 563);
+			this.MinimumSize = new System.Drawing.Size(700, 574);
 			this.Name = "MapForm";
 			this.Text = "YOGEME Map Interface";
 			this.Activated += new System.EventHandler(this.form_Activated);
@@ -624,6 +955,7 @@ namespace Idmr.Yogeme
 			this.grpPoints.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.numRegion)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numOrder)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numSnapAmount)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
@@ -669,15 +1001,39 @@ namespace Idmr.Yogeme
 		private NumericUpDown numRegion;
 		private Label lblOrder;
 		private NumericUpDown numOrder;
-		private Label label1;
-        private ListBox lstVisible;
-        private Label label3;
+        private ListBox lstCraft;
         private Button cmdHideNone;
-        private Button cmdHideAll;
-        private ListBox lstSelected;
-        private Label lblQuickHide;
+        private ListBox lstSelection;
+        private Label lblSelection;
         private Button cmdHelp;
         private CheckBox chkDistance;
 		private Timer mapPaintRedrawTimer;
+		private Label lblFade;
+		private Button cmdFadeAdd;
+		private Button cmdFadeNone;
+		private Button cmdFadeSubtract;
+		private Label lblHide;
+		private Button cmdHideAdd;
+		private Button cmdHideSubtract;
+		private ComboBox cboSnapUnit;
+		private Label lblSnapTo;
+		private ComboBox cboSnapTo;
+		private NumericUpDown numSnapAmount;
+		private Label lblExpandSelection;
+		private Button cmdExpandByCraft;
+		private Button cmdExpandByIff;
+		private Button cmdExpandBySize;
+		private Button cmdInvertSelection;
+		private CheckBox chkTime;
+		private CheckBox chkTraceHideFade;
+		private CheckBox chkTraceSelected;
+		private Button cmdFitSelected;
+		private Label lblFit;
+		private Button cmdFitWorld;
+		private Button cmdFitDefault;
+		private Label lblCenterOn;
+		private Button cmdCenterSelected;
+		private ComboBox cboViewDifficulty;
+		private ComboBox cboViewIff;
 	}
 }

--- a/OptionsDialog.Designer.cs
+++ b/OptionsDialog.Designer.cs
@@ -42,6 +42,10 @@ namespace Idmr.Yogeme
 			this.chkVerify = new System.Windows.Forms.CheckBox();
 			this.chkSave = new System.Windows.Forms.CheckBox();
 			this.tabMap = new System.Windows.Forms.TabPage();
+			this.cboMiddleClickAction = new System.Windows.Forms.ComboBox();
+			this.cboMiddleClickActionSelected = new System.Windows.Forms.ComboBox();
+			this.label17 = new System.Windows.Forms.Label();
+			this.label16 = new System.Windows.Forms.Label();
 			this.lblMouseWheelZoom = new System.Windows.Forms.Label();
 			this.numMousewheelZoom = new System.Windows.Forms.NumericUpDown();
 			this.groupBox2 = new System.Windows.Forms.GroupBox();
@@ -375,6 +379,10 @@ namespace Idmr.Yogeme
 			// 
 			// tabMap
 			// 
+			this.tabMap.Controls.Add(this.cboMiddleClickAction);
+			this.tabMap.Controls.Add(this.cboMiddleClickActionSelected);
+			this.tabMap.Controls.Add(this.label17);
+			this.tabMap.Controls.Add(this.label16);
 			this.tabMap.Controls.Add(this.lblMouseWheelZoom);
 			this.tabMap.Controls.Add(this.numMousewheelZoom);
 			this.tabMap.Controls.Add(this.groupBox2);
@@ -385,6 +393,52 @@ namespace Idmr.Yogeme
 			this.tabMap.Size = new System.Drawing.Size(397, 238);
 			this.tabMap.TabIndex = 4;
 			this.tabMap.Text = "Map";
+			// 
+			// cboMiddleClickAction
+			// 
+			this.cboMiddleClickAction.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboMiddleClickAction.FormattingEnabled = true;
+			this.cboMiddleClickAction.Items.AddRange(new object[] {
+            "Do nothing",
+            "Reset view to center",
+            "Fit to world"});
+			this.cboMiddleClickAction.Location = new System.Drawing.Point(6, 193);
+			this.cboMiddleClickAction.Name = "cboMiddleClickAction";
+			this.cboMiddleClickAction.Size = new System.Drawing.Size(132, 21);
+			this.cboMiddleClickAction.TabIndex = 7;
+			// 
+			// cboMiddleClickActionSelected
+			// 
+			this.cboMiddleClickActionSelected.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboMiddleClickActionSelected.FormattingEnabled = true;
+			this.cboMiddleClickActionSelected.Items.AddRange(new object[] {
+            "Do nothing",
+            "Reset view to center",
+            "Fit to world",
+            "Fit to selection",
+            "Center over selection"});
+			this.cboMiddleClickActionSelected.Location = new System.Drawing.Point(6, 147);
+			this.cboMiddleClickActionSelected.Name = "cboMiddleClickActionSelected";
+			this.cboMiddleClickActionSelected.Size = new System.Drawing.Size(132, 21);
+			this.cboMiddleClickActionSelected.TabIndex = 6;
+			// 
+			// label17
+			// 
+			this.label17.AutoSize = true;
+			this.label17.Location = new System.Drawing.Point(3, 177);
+			this.label17.Name = "label17";
+			this.label17.Size = new System.Drawing.Size(136, 13);
+			this.label17.TabIndex = 5;
+			this.label17.Text = "Middle click: none selected";
+			// 
+			// label16
+			// 
+			this.label16.AutoSize = true;
+			this.label16.Location = new System.Drawing.Point(3, 131);
+			this.label16.Name = "label16";
+			this.label16.Size = new System.Drawing.Size(109, 13);
+			this.label16.TabIndex = 5;
+			this.label16.Text = "Middle click: selected";
 			// 
 			// lblMouseWheelZoom
 			// 
@@ -1793,5 +1847,9 @@ namespace Idmr.Yogeme
 		private CheckBox chkXvtDetectMission;
 		private CheckBox chkXwaDetectMission;
 		private Label lblExportWarning;
+		private ComboBox cboMiddleClickActionSelected;
+		private Label label16;
+		private ComboBox cboMiddleClickAction;
+		private Label label17;
 	}
 }

--- a/OptionsDialog.cs
+++ b/OptionsDialog.cs
@@ -164,6 +164,9 @@ namespace Idmr.Yogeme
 			bool exportInUse = _config.XwaOverrideExternal && CraftDataManager.GetInstance().XwaInstallSpecificExternalDataLoaded;
 			lblExportWarning.Visible = exportInUse;
 
+			cboMiddleClickActionSelected.SelectedIndex = (int)_config.MapMiddleClickActionSelected;
+			cboMiddleClickAction.SelectedIndex = (int)_config.MapMiddleClickActionNoneSelected;
+
 			_closeCallback = callback;
 		}
 
@@ -303,7 +306,8 @@ namespace Idmr.Yogeme
 			int temp = 0;
 			for (int i = 0; i < 22; i++) temp += (chkWP[i].Checked ? 1 << i : 0);
 			_config.Waypoints = temp;
-			_config.MapOptions = (chkFG.Checked ? Settings.MapOpts.FGTags : Settings.MapOpts.None) | (chkTrace.Checked ? Settings.MapOpts.Traces : Settings.MapOpts.None);
+			_config.MapOptions = (_config.MapOptions ^ (_config.MapOptions & Settings.MapOpts.FGTags)) | (chkFG.Checked ? Settings.MapOpts.FGTags : Settings.MapOpts.None);
+			_config.MapOptions = (_config.MapOptions ^ (_config.MapOptions & Settings.MapOpts.Traces)) | (chkTrace.Checked ? Settings.MapOpts.Traces : Settings.MapOpts.None);
 			_config.XwingCraft = (byte)cboXWCraft.SelectedIndex;
 			_config.XwingIff = (byte)cboXWIFF.SelectedIndex;
 			_config.TieCraft = (byte)cboTIECraft.SelectedIndex;
@@ -354,6 +358,9 @@ namespace Idmr.Yogeme
 			_config.XwaOverrideExternal = chkXwaOverrideExternal.Checked;
 			_config.XwaOverrideScan = chkXwaOverrideScan.Checked;
 			_config.XwaFlagRemappedCraft = chkXwaFlagRemappedCraft.Checked;
+
+			_config.MapMiddleClickActionSelected = (MapForm.MiddleClickAction)cboMiddleClickActionSelected.SelectedIndex;
+			_config.MapMiddleClickActionNoneSelected = (MapForm.MiddleClickAction)cboMiddleClickAction.SelectedIndex;
 
 			_closeCallback?.Invoke(0, new EventArgs());
 			Close();

--- a/TieForm.Designer.cs
+++ b/TieForm.Designer.cs
@@ -4436,6 +4436,7 @@ namespace Idmr.Yogeme
 			this.Text = "Ye Olde Galactic Empire Mission Editor - TIE";
 			this.Activated += new System.EventHandler(this.form_Activated);
 			this.Closing += new System.ComponentModel.CancelEventHandler(this.form_Closing);
+			this.Deactivate += new System.EventHandler(this.form_Deactivate);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.form_KeyDown);
 			this.tabMain.ResumeLayout(false);
 			this.tabFG.ResumeLayout(false);

--- a/TieForm.cs
+++ b/TieForm.cs
@@ -871,6 +871,11 @@ namespace Idmr.Yogeme
 				lstFG.SelectedIndex = _activeFG;
 			}
 		}
+		void form_Deactivate(object sender, EventArgs e)
+		{
+			// Exit focus from any form controls. This submits changes to the map (if it's open), and can prevent issues if coming back in.
+			lstFG.Focus();
+		}
 		void form_Closing(object sender, System.ComponentModel.CancelEventArgs e)
 		{
 			promptSave();

--- a/XvtForm.Designer.cs
+++ b/XvtForm.Designer.cs
@@ -6770,6 +6770,7 @@ namespace Idmr.Yogeme
 			this.Text = "Ye Olde Galactic Empire Mission Editor - XvT";
 			this.Activated += new System.EventHandler(this.form_Activated);
 			this.Closing += new System.ComponentModel.CancelEventHandler(this.form_Closing);
+			this.Deactivate += new System.EventHandler(this.form_Deactivate);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.form_KeyDown);
 			this.tabMain.ResumeLayout(false);
 			this.tabFG.ResumeLayout(false);

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -1122,6 +1122,11 @@ namespace Idmr.Yogeme
 				lstFG.SelectedIndex = _activeFG;
 			}
 		}
+		void form_Deactivate(object sender, EventArgs e)
+		{
+			// Exit focus from any form controls. This submits changes to the map (if it's open), and can prevent issues if coming back in.
+			lstFG.Focus();
+		}
 		void form_Closing(object sender, System.ComponentModel.CancelEventArgs e)
 		{
 			promptSave();

--- a/XwaForm.Designer.cs
+++ b/XwaForm.Designer.cs
@@ -9263,6 +9263,7 @@ namespace Idmr.Yogeme
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
 			this.Text = "Ye Olde Galactic Empire Mission Editor - XWA";
 			this.Activated += new System.EventHandler(this.form_Activated);
+			this.Deactivate += new System.EventHandler(this.form_Deactivate);
 			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.form_Closing);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.form_KeyDown);
 			((System.ComponentModel.ISupportInitialize)(this.dataWaypoints)).EndInit();

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -1333,6 +1333,11 @@ namespace Idmr.Yogeme
 				lstFG.SelectedIndex = _activeFG;
 			}
 		}
+		void form_Deactivate(object sender, EventArgs e)
+		{
+			// Exit focus from any form controls. This submits changes to the map (if it's open), and can prevent issues if coming back in.
+			lstFG.Focus();
+		}
 		void form_Closing(object sender, FormClosingEventArgs e)
 		{
 			if (e.CloseReason == CloseReason.ApplicationExitCall) return;

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -3854,8 +3854,11 @@ namespace Idmr.Yogeme
 		{
 			bool btemp = _loading;
 			_loading = true;
+			int oldSelection = cboWP.SelectedIndex;
+			if (oldSelection < 0)
+				oldSelection = 0;
 			cboWP.SelectedIndex = -1;   // force change
-			cboWP.SelectedIndex = 0;
+			cboWP.SelectedIndex = oldSelection;
 			for (int i = 0; i < 4; i++)
 			{
 				for (int j = 0; j < 3; j++)

--- a/XwingForm.Designer.cs
+++ b/XwingForm.Designer.cs
@@ -2272,6 +2272,7 @@ namespace Idmr.Yogeme
 			this.Text = "Ye Olde Galactic Empire Mission Editor - X-wing";
 			this.Activated += new System.EventHandler(this.form_Activated);
 			this.Closing += new System.ComponentModel.CancelEventHandler(this.form_Closing);
+			this.Deactivate += new System.EventHandler(this.form_Deactivate);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.form_KeyDown);
 			this.tabMain.ResumeLayout(false);
 			this.tabFG.ResumeLayout(false);

--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -610,6 +610,11 @@ namespace Idmr.Yogeme
 				lstFG.SelectedIndex = _activeFG;
 			}
 		}
+		void form_Deactivate(object sender, EventArgs e)
+		{
+			// Exit focus from any form controls. This submits changes to the map (if it's open), and can prevent issues if coming back in.
+			lstFG.Focus();
+		}
 		void form_Closing(object sender, System.ComponentModel.CancelEventArgs e)
 		{
 			promptSave();

--- a/classes/CraftData.cs
+++ b/classes/CraftData.cs
@@ -203,6 +203,15 @@ namespace Idmr.Yogeme
 			return result;
 		}
 
+		/// <summary>Retrieves the speed (in MGLT) of a craft.</summary>
+		public int GetCraftSpeed(int craftType)
+		{
+
+			if (craftType < 0 || craftType >= _finalizedCraftData.Count)
+				return 0;
+			return _finalizedCraftData[craftType].SpeedMglt;
+		}
+
 		/// <summary>Retrieves the detected install path.</summary>
 		public string GetInstallPath()
 		{

--- a/classes/MapWireframe.cs
+++ b/classes/MapWireframe.cs
@@ -1258,7 +1258,8 @@ namespace Idmr.Yogeme
 							{
 								resource.ReadFromStream(br);
 
-								_dosSpeciesMap.Add(resource.Name.ToLower(), filename);
+								if(!_dosSpeciesMap.ContainsKey(resource.Name.ToLower()))
+									_dosSpeciesMap.Add(resource.Name.ToLower(), filename);
 								if (_dosCraftFormat == LfdCraftFormat.None)
 									_dosCraftFormat = resource.GetCraftFormat();
 							}

--- a/classes/Settings.cs
+++ b/classes/Settings.cs
@@ -77,7 +77,7 @@ namespace Idmr.Yogeme
 		public enum Platform { None, TIE, XvT, BoP, XWA, XWING }
 		public enum StartupMode { Normal, LastPlatform, LastMission }
 		[Flags]
-		public enum MapOpts { None, FGTags, Traces }
+		public enum MapOpts { None = 0, FGTags = 1, Traces = 2, TraceDistance = 4, TraceTime = 8, TraceHideFade = 16, TraceSelected = 32 }
 
 		/// <summary>Creates a new Settings object and loads saved settings</summary>
 		public Settings()
@@ -130,6 +130,12 @@ namespace Idmr.Yogeme
 
 			XwaOverrideScan = true;
 			XwaFlagRemappedCraft = true;
+
+			MapMiddleClickActionSelected = MapForm.MiddleClickAction.FitToWorld;
+			MapMiddleClickActionNoneSelected = MapForm.MiddleClickAction.FitToWorld;
+			MapSnapTo = 0;
+			MapSnapAmount = 0.10f;
+			MapSnapUnit = 0;
 		}
 
 		/// <summary>Loads saved settings</summary>
@@ -244,6 +250,12 @@ namespace Idmr.Yogeme
 					XwaOverrideExternal = br.ReadBoolean();
 					XwaOverrideScan = br.ReadBoolean();
 					XwaFlagRemappedCraft = br.ReadBoolean();
+
+					MapMiddleClickActionSelected = (MapForm.MiddleClickAction)br.ReadInt32();
+					MapMiddleClickActionNoneSelected = (MapForm.MiddleClickAction)br.ReadInt32();
+					MapSnapTo = br.ReadByte();
+					MapSnapAmount = br.ReadSingle();
+					MapSnapUnit = br.ReadByte();
 				}
 				catch { System.Diagnostics.Debug.WriteLine("old settings file"); /*do nothing*/ }
 
@@ -583,6 +595,12 @@ namespace Idmr.Yogeme
 			bw.Write(XwaOverrideScan);
 			bw.Write(XwaFlagRemappedCraft);
 
+			bw.Write((int)MapMiddleClickActionSelected);
+			bw.Write((int)MapMiddleClickActionNoneSelected);
+			bw.Write(MapSnapTo);
+			bw.Write(MapSnapAmount);
+			bw.Write(MapSnapUnit);
+
 			fs.SetLength(fs.Position);
 			fs.Close();
 			#endregion
@@ -806,6 +824,17 @@ namespace Idmr.Yogeme
 		public bool XwaOverrideScan { get; set; }
 		/// <summary>Gets or sets whether a suffix should be added to craft names, indicating a craft type that has been remapped. Only applies when <see cref="XwaOverrideScan"/> is used.</summary>
 		public bool XwaFlagRemappedCraft { get; set; }
+
+		/// <summary>Gets or sets the action to perform when middle-clicking the map with something selected.</summary>
+		public MapForm.MiddleClickAction MapMiddleClickActionSelected { get; set; }
+		/// <summary>Gets or sets the action to perform when middle-clicking the map with nothing selected.</summary>
+		public MapForm.MiddleClickAction MapMiddleClickActionNoneSelected { get; set; }
+		/// <summary>Gets or sets whether map movement snapping is enabled, and to what.</summary>
+		public byte MapSnapTo { get; set; }
+		/// <summary>Gets or sets the distance if map movement snapping is enabled.</summary>
+		public float MapSnapAmount { get; set; }
+		/// <summary>Gets or sets the unit of measurement for map movement snapping.</summary>
+		public byte MapSnapUnit { get; set; }
 		#endregion
 	}
 	/* Settings and values


### PR DESCRIPTION
Huge update to the map interface, plus some misc fixes elsewhere.
Map is almost completely reworked.  The experimental "hide" feature has been revamped into something easier to use.
The craft lists provide easier selection.  Hide, fade, and filtering (by difficulty or IFF) for visibility.  Can also auto-hide waypoint traces for anything not currently selected.
Expand selection by craft, IFF, size, and invert selection for quickly selecting similar things.
Craft list is colorized by region (XWA) and filtering status.  Auto-resizes to an appropriate width based on craft strings.
Selected waypoints appear in the selection list to more easily pick them out of a crowd.
Can drag selected items directly without having to hold shift, but holding shift still works.
Control click can toggle selection, and control-drag can add to selection.
Fit to selection, fit to map, and center on selection allow quicker navigation.  These functions can be assigned to middle click in the options menu.
General map settings are preserved in options.
Time calculation for waypoint traces.  Since this needs to access the FG orders, the order selector is no longer restricted to XWA.
Movement snap to grid, and snap to self implemented.
Waypoint selection and creation via number keys.  Can move waypoints or start points to different region.
For now, the Help button lists most of these features for the user.
Returning focus to certain edit controls after exiting the map could throw exceptions when trying to refresh the FG.  This has been fixed.