### PR TITLE
XWA fixes

### DIFF
--- a/XwaForm.Designer.cs
+++ b/XwaForm.Designer.cs
@@ -765,7 +765,7 @@ namespace Idmr.Yogeme
 			this.lblGG9 = new System.Windows.Forms.Label();
 			this.lblGG1 = new System.Windows.Forms.Label();
 			this.txtGlobGroup = new System.Windows.Forms.TextBox();
-			this.groupBox38 = new System.Windows.Forms.GroupBox();
+			this.grpRegions = new System.Windows.Forms.GroupBox();
 			this.label137 = new System.Windows.Forms.Label();
 			this.label136 = new System.Windows.Forms.Label();
 			this.label135 = new System.Windows.Forms.Label();
@@ -954,7 +954,7 @@ namespace Idmr.Yogeme
 			((System.ComponentModel.ISupportInitialize)(this.numGCUnk2)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numGlobCargo)).BeginInit();
 			this.groupBox39.SuspendLayout();
-			this.groupBox38.SuspendLayout();
+			this.grpRegions.SuspendLayout();
 			this.groupBox37.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.dataOrders)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.dataOrders_Raw)).BeginInit();
@@ -8685,7 +8685,7 @@ namespace Idmr.Yogeme
 			// 
 			this.tabMission2.Controls.Add(this.groupBox40);
 			this.tabMission2.Controls.Add(this.groupBox39);
-			this.tabMission2.Controls.Add(this.groupBox38);
+			this.tabMission2.Controls.Add(this.grpRegions);
 			this.tabMission2.Controls.Add(this.groupBox37);
 			this.tabMission2.Controls.Add(this.label101);
 			this.tabMission2.Controls.Add(this.txtNotes);
@@ -9065,22 +9065,23 @@ namespace Idmr.Yogeme
 			this.txtGlobGroup.TabIndex = 0;
 			this.txtGlobGroup.Leave += new System.EventHandler(this.txtGlobGroup_Leave);
 			// 
-			// groupBox38
+			// grpRegions
 			// 
-			this.groupBox38.Controls.Add(this.label137);
-			this.groupBox38.Controls.Add(this.label136);
-			this.groupBox38.Controls.Add(this.label135);
-			this.groupBox38.Controls.Add(this.label134);
-			this.groupBox38.Controls.Add(this.txtRegion4);
-			this.groupBox38.Controls.Add(this.txtRegion3);
-			this.groupBox38.Controls.Add(this.txtRegion2);
-			this.groupBox38.Controls.Add(this.txtRegion1);
-			this.groupBox38.Location = new System.Drawing.Point(8, 157);
-			this.groupBox38.Name = "groupBox38";
-			this.groupBox38.Size = new System.Drawing.Size(191, 128);
-			this.groupBox38.TabIndex = 3;
-			this.groupBox38.TabStop = false;
-			this.groupBox38.Text = "Regions";
+			this.grpRegions.Controls.Add(this.label137);
+			this.grpRegions.Controls.Add(this.label136);
+			this.grpRegions.Controls.Add(this.label135);
+			this.grpRegions.Controls.Add(this.label134);
+			this.grpRegions.Controls.Add(this.txtRegion4);
+			this.grpRegions.Controls.Add(this.txtRegion3);
+			this.grpRegions.Controls.Add(this.txtRegion2);
+			this.grpRegions.Controls.Add(this.txtRegion1);
+			this.grpRegions.Location = new System.Drawing.Point(8, 157);
+			this.grpRegions.Name = "grpRegions";
+			this.grpRegions.Size = new System.Drawing.Size(191, 128);
+			this.grpRegions.TabIndex = 3;
+			this.grpRegions.TabStop = false;
+			this.grpRegions.Text = "Regions";
+			this.grpRegions.Leave += new System.EventHandler(this.grpRegions_Leave);
 			// 
 			// label137
 			// 
@@ -9489,8 +9490,8 @@ namespace Idmr.Yogeme
 			((System.ComponentModel.ISupportInitialize)(this.numGlobCargo)).EndInit();
 			this.groupBox39.ResumeLayout(false);
 			this.groupBox39.PerformLayout();
-			this.groupBox38.ResumeLayout(false);
-			this.groupBox38.PerformLayout();
+			this.grpRegions.ResumeLayout(false);
+			this.grpRegions.PerformLayout();
 			this.groupBox37.ResumeLayout(false);
 			this.groupBox37.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.dataOrders)).EndInit();
@@ -10093,7 +10094,7 @@ namespace Idmr.Yogeme
 		private TabPage tabMission2;
 		private GroupBox groupBox39;
 		private Label lblGG1;
-		private GroupBox groupBox38;
+		private GroupBox grpRegions;
 		private Label label137;
 		private Label label136;
 		private Label label135;

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -1340,7 +1340,7 @@ namespace Idmr.Yogeme
 			if (colorize && !e.State.HasFlag(DrawItemState.Selected)) e.Graphics.FillRectangle(Brushes.Black, e.Bounds);
 			Brush brText = SystemBrushes.ControlText;
 			if (colorize) brText = getFlightGroupDrawColor(e.Index - paramOffset);
-			if (brText == SystemBrushes.ControlText && variable.BackColor == Color.Black) brText = Brushes.LightGray;
+			if (colorize && brText == SystemBrushes.ControlText) brText = Brushes.LightGray;
 			e.Graphics.DrawString(e.Index >= 0 ? variable.Items[e.Index].ToString() : "", e.Font, brText, e.Bounds, StringFormat.GenericDefault);
 		}
 

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -5222,6 +5222,14 @@ namespace Idmr.Yogeme
 			_mission.GlobalCargo[gc].Unknown5 = Common.Update(this, _mission.GlobalCargo[gc].Unknown5, Convert.ToByte(numGCUnk5.Value));
 		}
 
+		void grpRegions_Leave(object sender, EventArgs e)
+		{
+			parameterRefresh(cboSkipPara);
+			parameterRefresh(cboGoalPara);
+			parameterRefresh(cboADPara);
+			parameterRefresh(cboMessPara);
+			parameterRefresh(cboGlobalPara);
+		}
 		void txtGlobCargo_Leave(object sender, EventArgs e)
 		{
 			int gc = (int)numGlobCargo.Value - 1;

--- a/classes/Settings.cs
+++ b/classes/Settings.cs
@@ -489,7 +489,7 @@ namespace Idmr.Yogeme
 				}
 			}
 			#endregion
-			if (XwaInstalled) SuperBackdropsInstalled = (File.Exists(_xwaPath + "\\DTMSBReadme.rtf") || File.Exists(_xwaPath + "\\Backup\\SBPReadme_v3.1.rtf") || Directory.Exists(_xwaPath + "\\Readme\\SuperBackdropPatch") || Directory.GetFiles(_xwaPath + "\\Readme\\Upgrades", "SuperBackdrop*").Length != 0 || File.Exists(_xwaPath + "\\Resdata\\Planet2.dat"));
+			if (XwaInstalled) SuperBackdropsInstalled = (File.Exists(_xwaPath + "\\DTMSBReadme.rtf") || File.Exists(_xwaPath + "\\Backup\\SBPReadme_v3.1.rtf") || Directory.Exists(_xwaPath + "\\Readme\\SuperBackdropPatch") || (Directory.Exists(_xwaPath + "\\Readme\\Upgrades") && Directory.GetFiles(_xwaPath + "\\Readme\\Upgrades", "SuperBackdrop*").Length != 0) || File.Exists(_xwaPath + "\\Resdata\\Planet2.dat"));
 		}
 		/// <summary>Saves current settings to user's settings file</summary>
 		/// <remarks>Registry use has been deprecated</remarks>


### PR DESCRIPTION
I received a bug report that build 1.9 wouldn't start, and I confirmed the problem.  During SuperBackdrop detection, it attempts to enumerate files from a directory that doesn't exist in a vanilla installation.

The user also reported a problem with the region names in the parameter dropdown lists.  Prior code-changes had introduced a bug, invisible text on a default color scheme.  This has now been corrected.

For good measure, editing the region names now refreshes the parameter list.  I renamed the regions GroupBox so that it would have a meaningful name in the code for the attached event function.