### PR TITLE
Fixed exceptions when entering non-numerical waypoints

### DIFF
--- a/TieForm.cs
+++ b/TieForm.cs
@@ -2719,7 +2719,10 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = (short)(Convert.ToDouble(_table.Rows[j][i]) * 160);
+					double cell = 0;
+					if (!double.TryParse(_table.Rows[j][i].ToString(), out cell))
+						_table.Rows[j][i] = 0;
+					short raw = (short)(cell * 160);
 					_mission.FlightGroups[_activeFG].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[j][i], raw);
 					_tableRaw.Rows[j][i] = raw;
 				}
@@ -2738,7 +2741,9 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = Convert.ToInt16(_tableRaw.Rows[j][i]);
+					short raw = 0;
+					if (!short.TryParse(_tableRaw.Rows[j][i].ToString(), out raw))
+						_tableRaw.Rows[j][i] = 0;
 					_mission.FlightGroups[_activeFG].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[j][i], raw);
 					_table.Rows[j][i] = Math.Round((double)raw / 160, 2);
 				}

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -3351,7 +3351,10 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = (short)(Convert.ToDouble(_table.Rows[j][i]) * 160);
+					double cell = 0;
+					if (!double.TryParse(_table.Rows[j][i].ToString(), out cell))
+						_table.Rows[j][i] = 0;
+					short raw = (short)(cell * 160);
 					_mission.FlightGroups[_activeFG].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[j][i], raw);
 					_tableRaw.Rows[j][i] = raw;
 				}
@@ -3370,7 +3373,9 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = Convert.ToInt16(_tableRaw.Rows[j][i]);
+					short raw = 0;
+					if (!short.TryParse(_tableRaw.Rows[j][i].ToString(), out raw))
+						_tableRaw.Rows[j][i] = 0;
 					_mission.FlightGroups[_activeFG].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[j][i], raw);
 					_table.Rows[j][i] = Math.Round((double)raw / 160, 2);
 				}

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -4048,7 +4048,10 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = (short)Math.Round(Convert.ToDouble(_tableWP.Rows[j][i]) * 160);
+					double cell = 0;
+					if (!double.TryParse(_tableWP.Rows[j][i].ToString(), out cell))
+						_tableWP.Rows[j][i] = 0;
+					short raw = (short)Math.Round(cell * 160);
 					_mission.FlightGroups[_activeFG].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[j][i], raw);
 					_tableWPRaw.Rows[j][i] = raw;
 				}
@@ -4067,7 +4070,9 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = Convert.ToInt16(_tableWPRaw.Rows[j][i]);
+					short raw = 0;
+					if (!short.TryParse(_tableWPRaw.Rows[j][i].ToString(), out raw))
+						_tableWPRaw.Rows[j][i] = 0;
 					_mission.FlightGroups[_activeFG].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[j][i], raw);
 					_tableWP.Rows[j][i] = Math.Round((double)raw / 160, 2);
 				}
@@ -4088,7 +4093,10 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = (short)Math.Round(Convert.ToDouble(_tableOrder.Rows[j][i]) * 160);
+					double cell = 0;
+					if (!double.TryParse(_tableOrder.Rows[j][i].ToString(), out cell))
+						_tableOrder.Rows[j][i] = 0;
+					short raw = (short)Math.Round(cell * 160);
 					_mission.FlightGroups[_activeFG].Orders[region, order].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Orders[region, order].Waypoints[j][i], raw);
 					_tableOrderRaw.Rows[j][i] = raw;
 				}
@@ -4109,7 +4117,9 @@ namespace Idmr.Yogeme
 			{
 				for (i = 0; i < 3; i++)
 				{
-					short raw = Convert.ToInt16(_tableOrderRaw.Rows[j][i]);
+					short raw = 0;
+					if (!short.TryParse(_tableOrderRaw.Rows[j][i].ToString(), out raw))
+						_tableOrderRaw.Rows[j][i] = 0;
 					_mission.FlightGroups[_activeFG].Orders[region, order].Waypoints[j][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Orders[region, order].Waypoints[j][i], raw);
 					_tableOrder.Rows[j][i] = Math.Round((double)raw / 160, 2);
 				}

--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -2247,7 +2247,10 @@ namespace Idmr.Yogeme
 				int wpIndex = _waypointMapping[j];
 				for (i = 0; i < 3; i++)
 				{
-					short raw = (short)(Convert.ToDouble(_table.Rows[j][i]) * 160);
+					double cell = 0;
+					if (!double.TryParse(_table.Rows[j][i].ToString(), out cell))
+						_table.Rows[j][i] = 0;
+					short raw = (short)(cell * 160);
 					_mission.FlightGroups[_activeFG].Waypoints[wpIndex][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[wpIndex][i], raw);
 					_tableRaw.Rows[j][i] = raw;
 				}
@@ -2267,7 +2270,9 @@ namespace Idmr.Yogeme
 				int wpIndex = _waypointMapping[j];
 				for (i = 0; i < 3; i++)
 				{
-					short raw = Convert.ToInt16(_tableRaw.Rows[j][i]);
+					short raw = 0;
+					if (!short.TryParse(_tableRaw.Rows[j][i].ToString(), out raw))
+						_tableRaw.Rows[j][i] = 0;
 					_mission.FlightGroups[_activeFG].Waypoints[wpIndex][i] = Common.Update(this, _mission.FlightGroups[_activeFG].Waypoints[wpIndex][i], raw);
 					_table.Rows[j][i] = Math.Round((double)raw / 160, 2);
 				}


### PR DESCRIPTION
~~Previously, entering non-numerical values into a waypoint grid, or deleting a cell without providing a number, would throw an exception.
This avoids the exception and resets the cell value back to zero if an invalid string is entered.
Note: I noticed that XWA used an additional Math.Round() operation, when the other platforms didn't.  I didn't know if there was any reason why, so I kept as is.~~

EDIT: Only realized after the fact, this doesn't occur in release builds... because of the try/catch... because of course.
Well, at least it won't explode when running in the debugger.  I got burned by that issue when editing a test mission, so I was compelled to fix it.  Not sure if I should keep this or not.