### PR TITLE
Map wireframe non-waypoint craft orientation

### DIFF
--- a/MapForm.cs
+++ b/MapForm.cs
@@ -268,7 +268,10 @@ namespace Idmr.Yogeme
 				meshZoom = (int)(_zoom * scale);
 			}
 
-			model.UpdateParams(dat.WPs[0][0], dst, meshZoom, _displayMode, _settings.WireframeMeshTypeVisibility);
+			if (_platform == Settings.Platform.XWA && !dst.Enabled)
+				model.UpdateSimple(meshZoom, _settings.WireframeMeshTypeVisibility, dat.Yaw, dat.Pitch, dat.Roll);
+			else
+				model.UpdateParams(dat.WPs[0][0], dst, meshZoom, _displayMode, _settings.WireframeMeshTypeVisibility);
 
 			Pen body = new Pen((dat.View == Visibility.Fade ? _fadeColor : getIFFColor(dat.IFF)));
 			Pen hangar = new Pen((dat.View == Visibility.Fade ? _fadeColor : Color.White));
@@ -2111,7 +2114,10 @@ namespace Idmr.Yogeme
 					Name = fg[i].Name,
 					FlightGroup = fg[i],
 					Difficulty = getDifficultyFlags(fg[i].Difficulty),
-					Region = fg[i].Waypoints[0].Region
+					Region = fg[i].Waypoints[0].Region,
+					Pitch = fg[i].Pitch,
+					Yaw = fg[i].Yaw,
+					Roll = fg[i].Roll,
 				};
 				_mapData[i].WPs[0] = fg[i].Waypoints;
 				for (int j = 0; j < 16; j++)
@@ -2162,6 +2168,9 @@ namespace Idmr.Yogeme
 				case Settings.Platform.XWA:
 					abbrev = Platform.Xwa.Strings.CraftAbbrv;
 					_mapData[index].Region = ((Platform.Xwa.FlightGroup)fg).Waypoints[0].Region;
+					_mapData[index].Yaw = ((Platform.Xwa.FlightGroup)fg).Yaw;
+					_mapData[index].Pitch = ((Platform.Xwa.FlightGroup)fg).Pitch;
+					_mapData[index].Roll = ((Platform.Xwa.FlightGroup)fg).Roll;
 					break;
 			}
 			if (abbrev != null)
@@ -2854,6 +2863,9 @@ namespace Idmr.Yogeme
 				Difficulty = 0;
 				FlightGroup = null;
 				Region = 0;
+				Yaw = 0;
+				Pitch = 0;
+				Roll = 0;
 				
 				switch (platform)
 				{
@@ -2889,7 +2901,9 @@ namespace Idmr.Yogeme
 			public int Difficulty;
 			public object FlightGroup;
 			public int Region;
-
+			public short Yaw;
+			public short Pitch;
+			public short Roll;
 			public Platform.BaseFlightGroup.BaseWaypoint[][] WPs;
 		}
 

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -4029,14 +4029,17 @@ namespace Idmr.Yogeme
 		void numPitch_Leave(object sender, EventArgs e)
 		{
 			_mission.FlightGroups[_activeFG].Pitch = Common.Update(this, _mission.FlightGroups[_activeFG].Pitch, (short)numPitch.Value);
+			refreshMap(_activeFG);
 		}
 		void numRoll_Leave(object sender, EventArgs e)
 		{
 			_mission.FlightGroups[_activeFG].Roll = Common.Update(this, _mission.FlightGroups[_activeFG].Roll, (short)numRoll.Value);
+			refreshMap(_activeFG);
 		}
 		void numYaw_Leave(object sender, EventArgs e)
 		{
 			_mission.FlightGroups[_activeFG].Yaw = Common.Update(this, _mission.FlightGroups[_activeFG].Yaw, (short)numYaw.Value);
+			refreshMap(_activeFG);
 		}
 
 		void tableWP_RowChanged(object sender, DataRowChangeEventArgs e)


### PR DESCRIPTION
Implementation for special behavior in XWA that doesn't exist in the other platforms.  If no waypoint is enabled, the craft's pitch/yaw/roll orientation (on the waypoint tab) is applied to the craft when the mission starts.

The map now keeps track of these craft settings.  When the condition is met, a different vertex transformation is applied.

If the orientation values on the waypoint tab are changed, the map will refresh.

Also combined scaling into the rotation matrix itself, instead of multiplying it separately per-vertex.  Should be a small performance gain, but drawing complex models is still slow.

Known issue: combining roll with pitch or yaw will produce incorrect rotations in the map.  Roll needs to be applied relative to the craft instead of the world, and that requires a different kind of transformation that the current method cannot fulfill.