### PR TITLE
XWA and XWAU enhancements

### DIFF
--- a/BriefingForm.cs
+++ b/BriefingForm.cs
@@ -65,6 +65,7 @@ using System.Data;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Windows.Forms;
+using System.IO;
 
 namespace Idmr.Yogeme
 {
@@ -345,7 +346,9 @@ namespace Idmr.Yogeme
 			cboCraft.Items.AddRange(Platform.Xwa.Strings.CraftType);
 			cboNCraft.Items.AddRange(Platform.Xwa.Strings.CraftType);
 			#endregion
-			importIcons(Application.StartupPath + "\\images\\XWA_BRF.bmp", 56);
+			// Try loading directly from the installation.  If it fails, load the default image strip.
+			if (!loadXwaIcons(56))
+				importIcons(Application.StartupPath + "\\images\\XWA_BRF.bmp", 56);
 			_tags = _xwaBriefing.BriefingTag;
 			_strings = _xwaBriefing.BriefingString;
 			importStrings();
@@ -427,6 +430,51 @@ namespace Idmr.Yogeme
 			cboFGTag.Items.Add(name);
 		}
 
+		/// <summary>Attempts to load XWA's briefing icons directly from the installation files.</summary>
+		bool loadXwaIcons(int size)
+		{
+			try
+			{
+				System.Collections.Generic.List<string> shiplist = new System.Collections.Generic.List<string>(232);
+				string line;
+				using (StreamReader sr = new StreamReader(CraftDataManager.GetInstance().GetInstallPath() + "\\SHIPLIST.TXT"))
+				{
+					while (!sr.EndOfStream)
+					{
+						line = sr.ReadLine();
+						if (line.StartsWith("!")) shiplist.Add(line);
+					}
+				}
+				Image bmp = Image.FromFile(CraftDataManager.GetInstance().GetInstallPath() + "\\FRONTRES\\MAPICONS\\LICON.BMP");
+				imgCraft.ImageSize = new Size(size, size);
+				for (int i = 0; i < shiplist.Count; i++)
+				{
+					Bitmap icon = new Bitmap(size, size);
+					using (Graphics g = Graphics.FromImage(icon))
+					{
+						string[] tokens = shiplist[i].Split(',');
+						int x1 = 0, x2 = 0, y1 = 0, y2 = 0, width = 0, height = 0;
+						if (tokens.Length >= 13) // Extraneous commas may exist.
+						{
+							int.TryParse(tokens[9].Trim(), out x1);
+							int.TryParse(tokens[10].Trim(), out y1);
+							int.TryParse(tokens[11].Trim(), out x2);
+							int.TryParse(tokens[12].Trim(), out y2);
+							width = x2 - x1;
+							height = y2 - y1;
+						}
+						Rectangle src = new Rectangle(x1, y1, width, height);
+						if (width > size) width = size;
+						if (height > size) height = size;
+						Rectangle dest = new Rectangle((size / 2) - (width / 2), (size / 2) - (height / 2), width, height);
+						g.DrawImage(bmp, dest, src, GraphicsUnit.Pixel);
+					}
+					imgCraft.Images.Add(icon);
+				}
+			}
+			catch { return false; }
+			return true;
+		}
 		void importIcons(string filename, int size)
 		{
 			try

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -2960,7 +2960,7 @@ namespace Idmr.Yogeme
 			cboCounter.SelectedIndex = _mission.FlightGroups[_activeFG].Countermeasures;
 			numExplode.Value = _mission.FlightGroups[_activeFG].ExplosionTime;
 			numBackdrop.Value = _mission.FlightGroups[_activeFG].Backdrop;
-			cboGlobCargo.SelectedIndex = _mission.FlightGroups[_activeFG].GlobalCargo;
+			Common.SafeSetCBO(cboGlobCargo, _mission.FlightGroups[_activeFG].GlobalCargo, true);
 			cboGlobSpecCargo.SelectedIndex = _mission.FlightGroups[_activeFG].GlobalSpecialCargo;
 			#endregion
 			#region Arr/Dep

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -842,6 +842,14 @@ namespace Idmr.Yogeme
 				int gg = Common.ParseIntAfter(text, "GG:");
 				text = text.Replace("GG:" + gg, ((gg >= 0 && gg < 16 && _mission.GlobalGroups[gg] != "") ? "GG " + gg + ": " + _mission.GlobalGroups[gg] : "Global Group " + gg));
 			}
+			while (text.Contains("REG:"))
+			{
+				int reg = Common.ParseIntAfter(text, "REG:");
+				string regName = "#" + (reg + 1);
+				if (reg >= 0 && reg < 4 && !_mission.Regions[reg].ToUpper().StartsWith("REGION"))
+					regName += " (" +_mission.Regions[reg] + ")";
+				text = text.Replace("REG:" + reg, regName);
+			}
 			return text;
 		}
 		void saveMission(string fileMission)
@@ -3748,6 +3756,7 @@ namespace Idmr.Yogeme
 					break;
 				case 0x32:  //Hyper to Region
 					text = "Region #" + (value + 1);
+					orderLabelRefresh(); // Special case, refreshes the region name directly in the order string.
 					break;
 				case 0xA:   //Escort
 					if (value < 9) text = "Above";

--- a/XwaForm.cs
+++ b/XwaForm.cs
@@ -286,7 +286,6 @@ namespace Idmr.Yogeme
 					break;
 				case 2: // Ship Type
 					cbo.Items.AddRange(Strings.CraftType);
-					cbo.Items.RemoveAt(0);
 					break;
 				case 3: // Ship Class
 					cbo.Items.AddRange(Strings.ShipClass);
@@ -334,7 +333,6 @@ namespace Idmr.Yogeme
 					break;
 				case 16: // All ship types except
 					cbo.Items.AddRange(Strings.CraftType);
-					cbo.Items.RemoveAt(0);
 					break;
 				case 17: // All ship classes except
 					cbo.Items.AddRange(Strings.ShipClass);


### PR DESCRIPTION
After playing with XWAU/TFTC, I found some issues that needed to be resolved.  Some issues were also reported by another user.

Fixed an off-by-one issue with the trigger ShipType lists (see the corresponding Platform pull request).  I may have inadvertently caused this bug, long ago.  Apparently XWA is unique in that it requires a null entry in the list.  TIE and XvT do not.

XWA order labels for "Hyper to Region" now include the region number in the text, and also the region name too, if defined.  (See the corresponding Platform pull request)

The briefing map now makes use of platform detection to try and load the icons directly from the the installation files.  It should be able to load TFTC briefings now.

In the XWA mission map, it now checks whether FlightGroups contain any hyper jump orders to the currently selected region, so their map visibility is no longer restricted to their starting region.  This brings it more in line with how AlliED handles the map display.

The XWAU Mission Objects hook introduced a feature where multiple craft profiles can be stored in a single OPT.  The map wireframe has been updated to load only the default profile for each model, to avoid drawing meshes that only appear on other profiles.  TODO: Ideally it would be able to draw the correct profile, but further changes are needed to provide that information to the map, and parts of the wireframe code would have to be modified to distinguish between each profile.  So for now it only loads the default profile.

While browsing TFTC missions I discovered some index-out-of-range exceptions on the cargo dropdown for some backdrops.  I haven't investigated if there's any particular reason why, maybe changes to their DAT files?  But at least it no longer throws an exception.