### PR TITLE
Set InvariantCulture as default

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -44,6 +44,8 @@
 using System;
 using System.IO;
 using System.Windows.Forms;
+using System.Threading;
+using System.Globalization;
 
 namespace Idmr.Yogeme
 {
@@ -52,6 +54,7 @@ namespace Idmr.Yogeme
 		[STAThread]
 		static void Main(string[] Args)
 		{
+			Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 			Settings config = new Settings();
             if (Args.Length != 1 && config.Startup == Settings.StartupMode.Normal) Application.Run(new StartForm(config));
 			else if (Args.Length != 1 && config.Startup == Settings.StartupMode.LastPlatform)


### PR DESCRIPTION
This fixes a localization issue that was preventing the XWA craft list scanner from working correctly.  If the operating system had different region/culture settings, certain string comparisons were failing.

Specifically, when loading XWA's string.txt file, the string operation `StartsWith("!KSPEC")` was silently failing on certain lines, so that the resulting craft list was incorrect.  Running a parsing test in a separate program, iterating through all possible cultures and counting the lines that passed the above operation, these cultures were producing unexpected line counts: arn-CL Mapuche (Chile), br-FR Breton (France), cs-CZ Czech (Czechia), cy-GB Welsh (United Kingdom), hsb-DE Upper Sorbian (Germany), hu-HU Hungarian (Hungary), sk-SK Slovak (Slovakia), ug-CN Uyghur (China), vi-VN Vietnamese (Vietnam)

Setting the thread's default culture to InvariantCulture seems to fix the problem.