### PR TITLE
Craft data loading and XW briefing fix

### DIFF
--- a/BriefingFormXwing.cs
+++ b/BriefingFormXwing.cs
@@ -240,6 +240,7 @@ namespace Idmr.Yogeme
 		}
 		void importEvents(Briefing.EventCollection rawEvents)
 		{
+			_events.Clear();
 			for (int i = 0; i < _maxEvents; i++)
 			{
 				try

--- a/classes/CraftData.cs
+++ b/classes/CraftData.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Windows.Forms;
 
 /* [JB] The manager class here is responsible for loading and storing all craft data and lists of names, as
  * well as detecting installation paths to load any needed files. It operates as singleton, allowing it to be
@@ -242,7 +243,7 @@ namespace Idmr.Yogeme
 				case Settings.Platform.XvT: case Settings.Platform.BoP: filename = "craft_data_xvt.txt"; break;
 				case Settings.Platform.XWA: filename = "craft_data_xwa.txt"; break;
 			}
-			_externalCraftData = loadCraftData(filename);
+			_externalCraftData = loadCraftData(Path.Combine(Application.StartupPath, filename));
 
 			var container = (_currentPlatform == Settings.Platform.XWING) ? _editorCraftData : _externalCraftData;
 			if (container != null && ((_currentPlatform == Settings.Platform.XWA && container.Count < _defaultCraftData.Count) || (_currentPlatform != Settings.Platform.XWA && container.Count != _defaultCraftData.Count)))


### PR DESCRIPTION
Loading the program via mission file drag-and-drop onto the executable, or via file extension association with the executable, would cause the program to assume the working directory of the mission file.  It would then be unable to locate the craft data text files.  The most notable side effect was preventing the wireframes from loading, as the asset information couldn't be loaded from the data files.  But it also prevented any string overrides from loading too.  This bug affected all platforms, but was less likely to impact XWA if "Scan craft list directly from installation" was checked.  Fixed by making the file path relative to the application directory.

Another issue was corruption when importing the XW briefing events.  The event list was continually appended on each import or page select operation, causing event duplication until the list was full.  Could be observed by repeatedly opening/closing the briefing, even on a new mission, and looking at the events tab.  Fixed by clearing any current event data before rebuilding the event list.