### PR TITLE
XW bug fixes

### DIFF
--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -1513,7 +1513,8 @@ namespace Idmr.Yogeme
 		{
 			if (objectType >= 0) objectType += 17;  // Expand from cbo SelectedIndex into proper item.
 			bool isFlightgroup = fg.IsFlightGroup();
-			if ((isFlightgroup && craftType == fg.CraftType) || (!isFlightgroup && objectType == fg.ObjectType))
+			// If changing from B-Wing to Y-Wing (both are craftType 2) we still need to apply the change below.
+			if ((isFlightgroup && craftType == fg.CraftType && craftType != 2) || (!isFlightgroup && objectType == fg.ObjectType))
 				return -1;
 			// Don't change if "none" is selected for the opposite type.
 			if (isFlightgroup && objectType == 17 || !isFlightgroup && craftType == 0)

--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -1454,7 +1454,7 @@ namespace Idmr.Yogeme
 						break;
 					case "PlatformValue": fg.Formation = Convert.ToByte(value); break;    // Multipurpose property
 					case "PlatformSeconds": fg.Formation = Convert.ToByte(value); break;
-					case "Status": fg.Status1 = Convert.ToByte(((int)value == 18 ? 10 : 0) + Convert.ToByte(value)); break;  // B-wing repeats codes at status 10 and higher
+					case "Status": fg.Status1 = Convert.ToByte((fg.Status1 >= 10 ? 10 : 0) + (int)value); break;  // B-wing repeats codes at status 10 and higher
 					case "ArriveViaHyper": fg.ArriveViaHyperspace = Convert.ToBoolean(value); break;
 					case "DepartViaHyper": fg.DepartViaHyperspace = Convert.ToBoolean(value); break;
 					case "Mothership": fg.Mothership = Convert.ToInt16(translateNullableFG((int)value)); break;

--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -1573,8 +1573,11 @@ namespace Idmr.Yogeme
 						fg.CraftType = 0;
 						fg.ObjectType = 25;
 					}
-					fg.CraftType = (byte)craftType;
-					fg.ObjectType = 0;
+					else
+					{
+						fg.CraftType = (byte)craftType;
+						fg.ObjectType = 0;
+					}
 				}
 				else
 				{

--- a/XwingForm.cs
+++ b/XwingForm.cs
@@ -1523,6 +1523,9 @@ namespace Idmr.Yogeme
 			// Have to poll these before changing the type, otherwise it interferes with search
 			int lastFlightgroup = _mission.FlightGroups.GetLastOfFlightGroup();
 			int lastObjectgroup = _mission.FlightGroups.GetLastOfObjectGroup();
+			int oldCraftType = fg.CraftType;
+			int oldObjectType = fg.ObjectType;
+			int oldStatus = fg.Status1;
 			if (_mode == EditorMode.XWI)
 			{
 				if (craftType >= 0)
@@ -1578,6 +1581,10 @@ namespace Idmr.Yogeme
 					fg.ObjectType = (short)objectType;
 				}
 			}
+
+			if(fg.CraftType != oldCraftType || fg.ObjectType != oldObjectType || fg.Status1 != oldStatus)
+				Common.MarkDirty(this);
+
 			return ret;
 		}
 		/// <summary>Moves a flightgroup slot to another, continuously swapping until it reaches its destination.</summary>


### PR DESCRIPTION
Four bugs fixed here:

Changing a craft type or object type doesn't flag the mission as dirty.  The mission can't be saved unless it's dirty.  Fixed by checking the new and old values (craft, object, and also status check for the Y/B wing) to see if anything changed.

Unable to change a B-Wing flightgroup back into a Y-Wing.  The new craft type matches the old one, therefore it skips the assignment.  Fixed by modifying the condition that was causing the skip.

Changing a B-Wing's status silently reverts the craft back into a Y-Wing.  Saving and reloading the mission, or swapping to BRF and back would now report a Y-Wing flightgroup.  The old code responsible for assigning the new status value was strange.  Fixed it.

In briefing mode, changing a flightgroup to the B-Wing via the craft type dropdown wouldn't properly assign the correct object type for the icon.  It would actually change to a Mine, not a B-Wing.  The conditional check that makes the proper icon assignment was correct, but overwritten by a separate assignment that occurs immediately afterward.  Fixed by moving into an `else` block.