### PR TITLE
Fixed XvT exception, order var refresh, and improved mission testing

### DIFF
--- a/TieForm.cs
+++ b/TieForm.cs
@@ -2404,6 +2404,7 @@ namespace Idmr.Yogeme
 			lblODesc.Text = s[0];
 			lblOVar1.Text = s[1];
 			lblOVar2.Text = s[2];
+			_activeOrder.Command = (byte)cboOrders.SelectedIndex;
 			numOVar1_ValueChanged(0, new EventArgs());
 			numOVar2_ValueChanged(0, new EventArgs());
 		}
@@ -2444,7 +2445,7 @@ namespace Idmr.Yogeme
 
 		void numOVar1_ValueChanged(object sender, EventArgs e)
 		{
-			byte variable = _activeOrder.Variable1;
+			byte variable = (byte)numOVar1.Value;
 			var command = (FlightGroup.Order.CommandList)_activeOrder.Command;
 			string text = "";
 			bool warning = false;
@@ -2490,7 +2491,7 @@ namespace Idmr.Yogeme
 		void numOVar2_ValueChanged(object sender, EventArgs e)
 		{
 			var command = (FlightGroup.Order.CommandList)_activeOrder.Command;
-			int variable = _activeOrder.Variable2;
+			byte variable = (byte)numOVar2.Value;
 			string text = "";
 			bool warning = false;
 			switch (command)

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -2903,6 +2903,7 @@ namespace Idmr.Yogeme
 			lblODesc.Text = s[0];
 			lblOVar1.Text = s[1];
 			lblOVar2.Text = s[2];
+			_activeOrder.Command = (byte)cboOrders.SelectedIndex;
 			numOVar1_ValueChanged(0, new EventArgs()); // Force refresh, since label information is provided to the user.
 			numOVar2_ValueChanged(0, new EventArgs());
 		}
@@ -2942,7 +2943,7 @@ namespace Idmr.Yogeme
 
 		void numOVar1_ValueChanged(object sender, EventArgs e)
 		{
-			byte value = _activeOrder.Variable1;
+			byte value = (byte)numOVar1.Value;
 			var command = (FlightGroup.Order.CommandList)_activeOrder.Command;
 			string text = "";
 			bool warning = false;
@@ -2986,7 +2987,7 @@ namespace Idmr.Yogeme
 		void numOVar2_ValueChanged(object sender, EventArgs e)
 		{
 			var command = (FlightGroup.Order.CommandList)_activeOrder.Command;
-			int value = _activeOrder.Variable2;
+			byte value = (byte)numOVar2.Value;
 			string text = "";
 			bool warning = false;
 			switch (command)

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -2482,7 +2482,7 @@ namespace Idmr.Yogeme
 					case "Status2": fg.Status2 = Convert.ToByte(value); break;
 					case "Missile": fg.Missile = Convert.ToByte(value); break;
 					case "Beam": fg.Beam = Convert.ToByte(value); break;
-					case "Countermeasures": fg.Countermeasures = (FlightGroup.CounterTypes)value; break;
+					case "Countermeasures": fg.Countermeasures = (FlightGroup.CounterTypes)Convert.ToByte(value); break;
 					case "ExplosionTime": fg.ExplosionTime = Convert.ToByte(value); break;
 					case "ArrivalMothership": fg.ArrivalMothership = Convert.ToByte(value); break;
 					case "AlternateMothership": fg.AlternateMothership = Convert.ToByte(value); break;

--- a/XvtForm.cs
+++ b/XvtForm.cs
@@ -1891,13 +1891,26 @@ namespace Idmr.Yogeme
 			int restart = 1;
 			Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon", true);*/
 
+			// Detect player team to set the appropriate list, and the faction selected in the pilot file
+			byte playerIff = 1;    // Default Imperial
+			foreach(FlightGroup fg in _mission.FlightGroups)
+			{
+				if(fg.PlayerNumber != 0)
+				{
+					playerIff = fg.IFF;
+					break;
+				}
+			}
+			if(playerIff > 1) playerIff = 1;
+
 			// configure XvT/BoP
+			string lstBase = (playerIff == 1 ? "Train\\IMPERIAL" : "Train\\REBEL");
 			int index = 0;
 			while (File.Exists(xvtPath + "test" + index + "0.plt")) index++;
 			string pilot = "test" + index + "0.plt";
 			string bopPilot = "test" + index + "0.pl2";
-			string lst = "Train\\IMPERIAL.LST";
-			string backup = "Train\\IMPERIAL_" + index + ".bak";
+			string lst = lstBase + ".LST";
+			string backup = lstBase + "_" + index + ".bak";
 
 			File.Copy(Application.StartupPath + "\\xvttest0.plt", xvtPath + pilot);
 			if (_config.BopInstalled) File.Copy(Application.StartupPath + "\\xvttest0.pl2", bopPath + bopPilot, true);
@@ -1908,6 +1921,8 @@ namespace Idmr.Yogeme
 				char[] indexBytes = index.ToString().ToCharArray();
 				new BinaryWriter(pilotFile).Write(indexBytes);
 				for (int i = (int)pilotFile.Position; i < 0xC; i++) pilotFile.WriteByte(0);
+				pilotFile.Position = 0x3EA6;
+				pilotFile.WriteByte(playerIff);
 			}
 			// BoP pilot edit
 			if (_config.BopInstalled)
@@ -1918,6 +1933,8 @@ namespace Idmr.Yogeme
 					char[] indexBytes = index.ToString().ToCharArray();
 					new BinaryWriter(pilotFile).Write(indexBytes);
 					for (int i = (int)pilotFile.Position; i < 0xC; i++) pilotFile.WriteByte(0);
+					pilotFile.Position = 0x3682;
+					pilotFile.WriteByte(playerIff);
 				}
 			}
 


### PR DESCRIPTION
There's an exception that pops up when trying to change the countermeasure in XvT.  Fixed with the appropriate cast from XWA.

The labels underneath the order parameter variables were not refreshing properly.  Either when changing the order command, or changing the parameter value.  This affected TIE and XvT.  Fixed with the appropriate lines from XWA.

The mission test tool for XvT has been improved.  It detects the player's IFF from the first playable flightgroup, then changes the appropriate .lst files in the train folder (either Rebel or Imperial).  When setting up the test pilot, it now writes the faction at the appropriate location.  That way, when the game launches and opens the pilot file, it starts with the correct faction selected.  Ready to click fly and jump into the replaced training exercise.  Works for both XvT and BoP.