### PR TITLE
Quick fixes, plus pending issue

### DIFF
--- a/BriefingForm2.cs
+++ b/BriefingForm2.cs
@@ -7112,7 +7112,8 @@ namespace Idmr.Yogeme
 				if (evt.Event >= start && evt.Event <= end)
 				{
 					int index = (evt.Event - start);
-					result[index] = evt.Time;
+					// Anything that's already in use must not be overwritten by a later time.
+					if (result[index] == -1) result[index] = evt.Time;
 				}
 				else if (evt.Event == clear || evt.Event == AbstractEventType.XwaChangeRegion)
 				{
@@ -9373,7 +9374,7 @@ namespace Idmr.Yogeme
 			for (int i = 0; i < count; i++)
 			{
 				// Prioritize empty slot, otherwise overwrite a future slot.
-				if (usage[i] == 0) return i;
+				if (usage[i] == -1) return i;
 				if (result == -1 && usage[i] > time) result = i;
 			}
 			return result;

--- a/classes/MapWireframe.cs
+++ b/classes/MapWireframe.cs
@@ -1187,7 +1187,7 @@ namespace Idmr.Yogeme.MapWireframe
 				}
 				def = new WireframeDefinition(craft);
 				def.Scale(scale);
-				craft.Craft.Dispose();
+				craft.Craft?.Dispose();
 			}
 			_wireframeDefinitions.Add(craftType, def);
 			return def;


### PR DESCRIPTION
In the new briefing, setting the tag usage init to -1 introduced a bug where all tags would be considered in use at all times.
Also fixed a secondary issue where a later usage would overwrite a previous one, which could prevent a warning if all tags actually were in use.

A user reported an exception when loading the mission map for an XW94 mission.  The craft model for the wireframe was not loading correctly, triggering a NRE on Dispose.
There's a simple fix here, but there's also a much bigger problem with the XW94 wireframes.

LfdReader\Crft.cs, DecodeResource uses `BitConverter.ToInt16`
LfdReader\Cplx.cs, DecodeResource uses `convertInt16` which reverses the endianness.  This was causing negative offsets, triggering an exception that prevented the craft from loading and being assigned.

Supposedly the Mac version swapped, but I don't have it to confirm.  If we're going to support the Mac version too, we'll need some way of testing and reacting.  Maybe we could check the first offset of the first component and see which byte is zero?  We'd have to check all the models and make sure they conform.  Another issue I realized is that all the offsets are signed Int16, which could potentially cause negative offsets.  I never noticed any problems when I initially wrote the parser, but it doesn't mean it's correct.